### PR TITLE
README markdown changes to allow the release-util.sh script to work.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,27 +30,25 @@ The quickstart README files use the *replaceable* value `EAP_HOME` to denote the
 * If you installed JBoss EAP using the RPM, the install directory is `/var/lib/jbossas/`.
 
 * If you used the installer to install JBoss EAP, the default path for `EAP_HOME` is `${user.home}/EAP-6.3.0`.  
-```
-For Linux: /home/USER_NAME/EAP-6.3.0/
-For Windows: "C:\Users\USER_NAME\EAP-6.3.0\"
-```
+
+        For Linux: /home/USER_NAME/EAP-6.3.0/
+        For Windows: "C:\Users\USER_NAME\EAP-6.3.0\"
+
 * If you used the JBoss Developer Studio installer to install and configure the JBoss EAP Server, the default path for `EAP_HOME` is `${user.home}/jbdevstudio/runtimes/jboss-eap`.  
-```
-For Linux: /home/USER_NAME/jbdevstudio/runtimes/jboss-eap/
-For Windows: "C:\Users\USER_NAME\jbdevstudio\runtimes\jboss-eap" or "C:\Documents and Settings\USER_NAME\jbdevstudio\runtimes\jboss-eap\" 
-```
+
+        For Linux: /home/USER_NAME/jbdevstudio/runtimes/jboss-eap/
+        For Windows: "C:\Users\USER_NAME\jbdevstudio\runtimes\jboss-eap" or "C:\Documents and Settings\USER_NAME\jbdevstudio\runtimes\jboss-eap\" 
+
 The `JBOSS_HOME` *environment* variable, which is used in scripts, continues to work as it has in the past.
 
 
 ## Available Quickstarts
 
-* `push-helloworld-android`, `push-helloworld-cordova` and `push-helloworld-ios` demonstrate how to include basic push functionality in mobile applications, provided in Android, Cordova and iOS variants. Once the application is deployed to a mobile device, the push functionality enables the device to register with a running JBoss Unified Push Server instance and receive push notifications.
+* [push-helloworld-android](push-helloworld-android/README.md), [push-helloworld-cordova](push-helloworld-cordova/README.md), and [push-helloworld-ios](push-helloworld-ios/README.md) demonstrate how to include basic push functionality in mobile applications, provided in Android, Cordova and iOS variants. Once the application is deployed to a mobile device, the push functionality enables the device to register with a running JBoss Unified Push Server instance and receive push notifications.
 
-* `push-contacts-mobile` shows how to develop a more advanced push example, centered around a CRUD contacts application. The complete `push-contacts-mobile` example functionality is provided by a server application and a client application. The server application sends push notification requests to a running JBoss Unified Push Server instance when new contacts are added. The client application enables devices to register with the Unified Push Server and receive push notifications with details of newly added contacts. The client application is provided in Android, Cordova, iOS and web application variants.
+* [push-contacts-mobile](push-contacts-mobile/README.md) shows how to develop a more advanced push example, centered around a CRUD contacts application. The complete `push-contacts-mobile` example functionality is provided by a server application and a client application. The server application sends push notification requests to a running JBoss Unified Push Server instance when new contacts are added. The client application enables devices to register with the Unified Push Server and receive push notifications with details of newly added contacts. The client application is provided in Android, Cordova, iOS and web application variants.
 
-The list of all currently available quickstarts can be found here: <http://site-jdf.rhcloud.com/quickstarts/get-started/>. The table lists each quickstart name, the technologies it demonstrates, gives a brief description of the quickstart, and the level of experience required to set it up. For more detailed information about a quickstart, click on the quickstart name.
-
-Some quickstarts are designed to enhance or extend other quickstarts. These are noted in the **Prerequisites** column. If a quickstart lists prerequisites, those must be installed or deployed before working with the quickstart.
+All available quickstarts can be found here: <http://site-jdf.rhcloud.com/quickstarts/get-started/>. You can filter by the quickstart name, the product, and the technologies demonstrated by the quickstart. You can also limit the results based on skill level and date published. The resulting page provides a brief description of each matching quickstart, the skill level, and the technologies used. Click on the quickstart to see more detailed information about how to run it. Some quickstarts require deployment of other quickstarts. This information is noted in the `Prerequisites` section of the quickstart README file.
 
 _Note_: Some of these quickstart use the H2 database included with JBoss EAP 6. It is a lightweight, relational example datasource that is used for examples only. It is not robust or scalable and should NOT be used in a production environment!
 
@@ -59,7 +57,6 @@ _Note_: Some of these quickstart use the H2 database included with JBoss EAP 6. 
 
 We suggest you approach the quickstarts as follows:
 
-* Regardless of your level of expertise, we suggest you start with the **helloworld** quickstart. It is the simplest example and is an easy way to prove your server is configured and started correctly.
 * If you are a beginner or new to JBoss, start with the quickstarts labeled **Beginner**, then try those marked as **Intermediate**. When you are comfortable with those, move on to the **Advanced** quickstarts.
 * Some quickstarts are based upon other quickstarts but have expanded capabilities and functionality. If a prerequisite quickstart is listed, be sure to deploy and test it before looking at the expanded version.
 
@@ -78,29 +75,18 @@ To run these quickstarts with the provided build scripts, you need the following
 2. Maven 3.0.0 or newer, to build and deploy the examples
     * If you have not yet installed Maven, see the [Maven Getting Started Guide](http://maven.apache.org/guides/getting-started/index.html) for details.
     * If you have installed Maven, you can check the version by typing the following in a command prompt:
-```
-mvn --version 
-```
+
+        mvn --version 
+
 3. The JBoss EAP distribution ZIP.
     * For information on how to install and run JBoss, see the [JBoss Enterprise Application Platform Documentation](https://access.redhat.com/documentation/en-US/JBoss_Enterprise_Application_Platform/) _Getting Started Guide_ located on the Customer Portal.
 
-4. You can also use [JBoss Developer Studio or Eclipse](## Use JBoss Developer Studio or Eclipse to Run the Quickstarts) to run the quickstarts. 
+4. You can also use [JBoss Developer Studio or Eclipse](#use-jboss-developer-studio-or-eclipse-to-run-the-quickstarts) to run the quickstarts. 
 
 
 ## Run the Quickstarts
 
-The root folder of each individual quickstart contains a README file with specific details on how to build and run the example. In most cases you do the following:
-
-* [Start the JBoss EAP Server](https://github.com/jboss-developer/jboss-developer-shared-resources/blob/master/guides/START_JBOSS_EAP.md#start-the-jboss-eap-server)
-* [Build and deploy the quickstarts](### Build and Deploy the Quickstarts)
-
-           
-### Build and Deploy the Quickstarts
-
-See the README file in each individual quickstart folder for specific details and information on how to run and access the example. 
-
-_Note:_ If you do not configure the Maven settings as described here, [Configure Maven](https://github.com/jboss-developer/jboss-developer-shared-resources/blob/master/guides/CONFIGURE_MAVEN.md#configure-maven-to-build-and-deploy-the-quickstarts), you must pass the configuration setting on every Maven command as follows: ` -s QUICKSTART_HOME/settings.xml`
-
+The root folder of each individual quickstart contains a README file with specific details on how to build and run the example. 
 
 
 ## Use JBoss Developer Studio or Eclipse to Run the Quickstarts

--- a/cordova_pushplugin/org.jboss.aerogear.cordova.push/README.md
+++ b/cordova_pushplugin/org.jboss.aerogear.cordova.push/README.md
@@ -5,77 +5,78 @@
 
 ## How do I use it?
 
-###0. System Requirements
+### 0. System Requirements
 
 * [Apache Cordova CLI](https://github.com/apache/cordova-cli/)
 * [Node.js](http://nodejs.org/download/)
 * Install Cordova by executing:
-  ```shell
-  $ npm install -g cordova
-  ```
-  To deploy on iOS you need to install also the ios-deploy package:
-  ```shell
-  npm install -g ios-deploy
-  ```
 
-###1. Pre-requisites
+        npm install -g cordova
+
+  To deploy on iOS you need to install also the ios-deploy package:
+
+        npm install -g ios-deploy
+
+
+### 1. Prerequisites
 
 Before building the application, you must register the Android or iOS variant of the application with a running JBoss Unified Push Server instance and Google Cloud Messaging for Android or Apple Push Notification Service for iOS. The resulting unique IDs and other parameters must then be inserted into the application source code. After this is complete, the application can be built and deployed to Android or iOS devices.
 
 For the configuration and registration of Android or iOS Applications with GCM or APNS, please refer to the specific guides inside `JBoss Unified Push for Android` and `JBoss Unified Push for iOS` libraries.
 
-###2. Use JBoss Unified Push PushPlugin for Cordova
+### 2. Use JBoss Unified Push PushPlugin for Cordova
 
 Extract the `JBoss Unified Push PushPlugin for Cordova` and install it specifying the local path to the plugin directory that contains the `plugin.xml` file, executing the following command from within your project folder:
-```shell
-cordova plugin add <path-to-org.jboss.aerogear.cordova.push-dir>
-```
+
+        cordova plugin add <path-to-org.jboss.aerogear.cordova.push-dir>
+
 
 Done! Your project now contains the JBoss Unified Push PushPlugin. For an integration with the `JBoss Unified Push Server` open the `www` folder in your text editor and apply the code from the example below. You can then execute the project with the command:
-```shell
-cordova run <android or ios>
-```
-## Example Usage
-###1. Register the application
-The following JavaScript code shows how to register a device with the JBoss Unified Push Server. You need to change `pushServerURL` with the url of your Unified Push Server instance. You also need to change `senderID`, `variantID` and `variantSecret` with the values assigned by Unified Push Server and GCM or APNS:
-```
-var pushConfig = {
-    pushServerURL: "<pushServerURL e.g http(s)//host:port/context >",
-    alias: "<alias e.g. a username or an email address optional>",
-    android: {
-      senderID: "<senderID e.g Google Project ID only for android>",
-      variantID: "<variantID e.g. 1234456-234320>",
-      variantSecret: "<variantSecret e.g. 1234456-234320>"
-    },
-    ios: {
-      variantID: "<variantID e.g. 1234456-234320>",
-      variantSecret: "<variantSecret e.g. 1234456-234320>"
-    }
-};
 
-push.register(onNotification, successHandler, errorHandler, pushConfig);
-```
+        cordova run <android or ios>
+
+## Example Usage
+
+### 1. Register the application
+
+The following JavaScript code shows how to register a device with the JBoss Unified Push Server. You need to change `pushServerURL` with the url of your Unified Push Server instance. You also need to change `senderID`, `variantID` and `variantSecret` with the values assigned by Unified Push Server and GCM or APNS:
+
+        var pushConfig = {
+            pushServerURL: "<pushServerURL e.g http(s)//host:port/context >",
+            alias: "<alias e.g. a username or an email address optional>",
+            android: {
+              senderID: "<senderID e.g Google Project ID only for android>",
+              variantID: "<variantID e.g. 1234456-234320>",
+              variantSecret: "<variantSecret e.g. 1234456-234320>"
+            },
+            ios: {
+              variantID: "<variantID e.g. 1234456-234320>",
+              variantSecret: "<variantSecret e.g. 1234456-234320>"
+            }
+        };
+        
+        push.register(onNotification, successHandler, errorHandler, pushConfig);
+
 
 If you are only targeting one platform, you can simplify the code above by:
 
-```
-var pushConfig = {
-    pushServerURL: "<pushServerURL e.g http(s)//host:port/context >",
-    alias: "<alias e.g. a username or an email address optional>",
-    variantID: "<ios variantID e.g. 1234456-234320>",
-    variantSecret: "<ios variantSecret e.g. 1234456-234320>"
-};
+        var pushConfig = {
+            pushServerURL: "<pushServerURL e.g http(s)//host:port/context >",
+            alias: "<alias e.g. a username or an email address optional>",
+            variantID: "<ios variantID e.g. 1234456-234320>",
+            variantSecret: "<ios variantSecret e.g. 1234456-234320>"
+        };
+        
+        push.register(onNotification, successHandler, errorHandler, pushConfig);
 
-push.register(onNotification, successHandler, errorHandler, pushConfig);
-```
 
-###2. Receive Remote Notifications
+### 2. Receive Remote Notifications
 The `onNotification` callback will get executed by the plugin when a new message arrives. 
-```
-function onNotification(event) {
-    alert(event.alert);
-}
-```
+
+        function onNotification(event) {
+            alert(event.alert);
+        }
+
 
 The passed in `event` object contains:
 
@@ -88,31 +89,31 @@ The passed in `event` object contains:
 #### iOS Background Notification
 Sending notifications that contain `content-available` on iOS will call the JavaScript before launching the application. This will enable you to update the UI or do a silent push (e.g. without an alert) to update the content of your application without the user noticing.  After fetching the content, you'll have to _inform_ the os about the result by calling `setContentAvailable` with either `NewData`, `NoData` or `Failed`:
 
-```
-function onNotification(event) {
 
-  if (event['content-available'] === 1) {
-    if (!event.foreground) {
-      // fetch content
-      push.setContentAvailable(push.FetchResult.NewData);
-    }
-  }
-}
-```
+        function onNotification(event) {
+        
+          if (event['content-available'] === 1) {
+            if (!event.foreground) {
+              // fetch content
+              push.setContentAvailable(push.FetchResult.NewData);
+            }
+          }
+        }
 
-###3. Unregister the Application (only available on Android):
 
-```
-push.unregister(successHandler, errorHandler);
+### 3. Unregister the Application (only available on Android):
 
-function successHandler() {
-    console.log('success')
-}
 
-function errorHandler(message) {
-    console.log('error ' + message);
-}
-```
+        push.unregister(successHandler, errorHandler);
+        
+        function successHandler() {
+            console.log('success')
+        }
+
+        function errorHandler(message) {
+            console.log('error ' + message);
+        }
+
 
 ## Demo
 For more information about configuring and using the JBoss Unified Push PushPlugin for Cordova, refer to `JBoss Unified Push Helloworld Cordova` and `JBoss Unified Push Contacts Mobile Cordova`, as examples of projects using the push feature with JBoss Unified Push for Cordova.

--- a/dist/release-utils.sh
+++ b/dist/release-utils.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+#
+# JBoss, Home of Professional Open Source
+# Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+# contributors by the @authors tag. See the copyright.txt in the
+# distribution for a full listing of individual contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+REQUIRED_BASH_VERSION=3.0.0
+
+if [[ $BASH_VERSION < $REQUIRED_BASH_VERSION ]]; then
+  echo "You must use Bash version 3 or newer to run this script"
+  exit
+fi
+
+
+DIR=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+
+# DEFINE
+
+ARCHETYPES=("jboss-javaee6-webapp-archetype" "jboss-javaee6-webapp-ear-archetype")
+QUICKSTARTS=("kitchensink" "kitchensink-ear")
+VERSIONS_MAVEN_PLUGIN_VERSION=1.3.1
+
+# SCRIPT
+
+HUMAN_READABLE_ARCHETYPES=""
+i=0
+element_count=${#ARCHETYPES[@]}
+index=0
+while [ "$index" -lt "$element_count" ]
+do
+   if [ $index -ne 0 ]
+   then
+      HUMAN_READABLE_ARCHETYPES="${HUMAN_READABLE_ARCHETYPES}, "
+   fi
+   HUMAN_READABLE_ARCHETYPES="${HUMAN_READABLE_ARCHETYPES}${ARCHETYPES[index]}"
+   ((index++))
+done
+
+
+usage()
+{
+cat << EOF
+usage: $0 options
+
+This script aids in releasing the quickstarts
+
+OPTIONS:
+   -u      Updates version numbers in all POMs, used with -o and -n      
+   -o      Old version number to update from
+   -n      New version number to update to
+   -r      Regenerate the various quickstarts based on archetypes ${HUMAN_READABLE_ARCHETYPES}
+   -m      Generate html versions of markdown readmes
+   -h      Shows this message
+EOF
+}
+
+update()
+{
+    cd $DIR/../
+    echo "Updating versions from $OLDVERSION TO $NEWVERSION for all Java files under $PWD"
+    perl -pi -e "s/${OLDVERSION}/${NEWVERSION}/g" `find . -name \*.java`
+
+    echo "Performing updates to POMs"
+    poms=`find . -type f -iname "pom.xml" -maxdepth 2 | sort`
+    for pom in $poms
+    do
+        echo "Updating ${pom}"
+        mvn org.codehaus.mojo:versions-maven-plugin:${VERSIONS_MAVEN_PLUGIN_VERSION}:set -DnewVersion=${NEWVERSION} -f ${pom} -q
+        mvn org.codehaus.mojo:versions-maven-plugin:${VERSIONS_MAVEN_PLUGIN_VERSION}:commit -f ${pom} -q
+    done
+}
+
+markdown_to_html()
+{
+   cd $DIR/../
+
+   # Clear the contents from toc.html file
+   rm dist/target/toc.html
+   touch dist/target/toc.html
+
+   # Loop through the sorted quickstart directories and process them
+   # Exclude the template directory since it's not a quickstart
+   subdirs=`find . -maxdepth 1 -type d ! -iname ".*" ! -iname "template" | sort`
+   for subdir in $subdirs
+   do
+      readmes=`find $subdir -iname readme.md`
+      for readme in $readmes
+      do
+         echo "Processing $readme"
+         output_filename=${readme//.md/.html}
+         output_filename=${output_filename//.MD/.html}
+         $DIR/github-flavored-markdown.rb $readme > $output_filename  
+      done
+   done
+   # Now process the root readme
+   cd $DIR/../
+   readme=README.md
+   echo "Processing $readme"
+   output_filename=${readme//.md/.html}
+   output_filename=${output_filename//.MD/.html}
+   $DIR/github-flavored-markdown.rb $readme > $output_filename  
+
+   # Now process the contributing markdown
+#   cd $DIR/../
+#   markdown_filename=CONTRIBUTING.md
+#   echo "Processing $markdown_filename"
+#   output_filename=${markdown_filename//.md/.html}
+#   output_filename=${output_filename//.MD/.html}
+#   $DIR/github-flavored-markdown.rb $markdown_filename > $output_filename  
+
+   # Now process the release procedure markdown
+#   cd $DIR/../
+#   markdown_filename=RELEASE_PROCEDURE.md
+#   echo "Processing $markdown_filename"
+#   output_filename=${markdown_filename//.md/.html}
+#   output_filename=${output_filename//.MD/.html}
+#   $DIR/github-flavored-markdown.rb $markdown_filename > $output_filename  
+}
+
+regenerate()
+{
+   TMPDIR="$DIR/target/regen"
+   ROOTDIR="$DIR/../"
+   
+   rm -rf $TMPDIR
+
+   mkdir -p $TMPDIR
+
+   cd $TMPDIR
+
+   element_count=${#ARCHETYPES[@]}
+   index=0
+   while [ "$index" -lt "$element_count" ]
+   do
+      archetype=${ARCHETYPES[index]}
+      quickstart=${QUICKSTARTS[index]}
+      package=${quickstart//-/_}
+      name="JBoss AS Quickstarts: $quickstart"
+      echo "**** Regenerating $quickstart from $archetype"
+      mvn archetype:generate -DarchetypeGroupId=org.jboss.spec.archetypes -DarchetypeArtifactId=$archetype -DarchetypeVersion=$VERSION -DartifactId=jboss-as-$quickstart -DgroupId=org.jboss.as.quickstarts -Dpackage=org.jboss.as.quickstarts.$package -Dversion=$VERSION -DinteractiveMode=false -Dname="${name}"
+      ((index++))
+      rm -rf $ROOTDIR/$quickstart
+      mv $TMPDIR/jboss-as-$quickstart $ROOTDIR/$quickstart
+   done
+
+}
+
+OLDVERSION="1.0.0-SNAPSHOT"
+NEWVERSION="1.0.0-SNAPSHOT"
+VERSION="1.0.0-SNAPSHOT"
+CMD="usage"
+
+while getopts “muo:n:r:” OPTION
+
+do
+     case $OPTION in
+         u)
+             CMD="update"
+             ;;
+         h)
+             usage
+             exit
+             ;;
+         o)
+             OLDVERSION=$OPTARG
+             ;;
+         n)
+             NEWVERSION=$OPTARG
+             ;;
+         r) 
+             CMD="regenerate"
+             VERSION=$OPTARG
+             ;;
+         m)
+             CMD="markdown_to_html"
+             ;;
+         [?])
+             usage
+             exit
+             ;;
+     esac
+done
+
+$CMD
+

--- a/push-contacts-mobile/README.md
+++ b/push-contacts-mobile/README.md
@@ -14,28 +14,26 @@ This project contains the JBoss Unified Push `push-contacts-mobile` quickstart. 
 
 The quickstart consists of several server and client applications, some of which must be deployed simultaneously to achieve a fully working example. Users can view, create and manage contacts through either applications on their mobile devices or a web application. On the creation of new contacts from any one of these applications, the Unified Push Server sends push notifications containing details of newly added contacts to devices that are registered with the Unified Push Server for the mobile contacts application.
 
-The following sections describe the individual applications that comprise this example.
+The following sections describe the individual applications that comprise this example.  
+
+_NOTE:_ See the individual quickstart README files for instructions to run them.
 
 ### Server-side Applications
 
 The source for the server applications is located in the `QUICKSTART_HOME/push-contacts-mobile/server` directory. These applications are deployed to the server and accessed by the client applications.
 
-* `push-contacts-mobile-picketlink-secured` is the core server-side application and fundamental to the example. It manages the contacts data, receiving the details of new contacts as they are created in the client applications and storing the details in a server-side database. It also sends push notification requests to the Unified Push Server when new contacts are created to initiate the sending of push notifications to registered devices. The server-side application rest endpoints are secured with PicketLink and can only be accessed by client applications with authenticated users. This application has no user interface. For information on how to deploy this application, see the [push-contacts-mobile-picketlink-secured README](server/push-contacts-mobile-picketlink-secured/README.md) file.
+* [push-contacts-mobile-picketlink-secured](server/push-contacts-mobile-picketlink-secured/README.md) is the core server-side application and fundamental to the example. It manages the contacts data, receiving the details of new contacts as they are created in the client applications and storing the details in a server-side database. It also sends push notification requests to the Unified Push Server when new contacts are created to initiate the sending of push notifications to registered devices. The server-side application rest endpoints are secured with PicketLink and can only be accessed by client applications with authenticated users. This application has no user interface.
 
-* `contacts-mobile-proxy` layers `push-contacts-mobile-picketlink-secured` and it can only be used in conjunction with the latter. It is intended for use when the `push-contacts-mobile-picketlink-secured` application is deployed on a server that is protected behind a firewall, preventing access by clients outside the firewall. The `contacts-mobile-proxy` is deployed on a server outside the firewall to act as a proxy or router application. This application has an accessible user interface, in which contacts can be viewed and managed as in the client applications. Note that this application has no push functionality. For information on how to deploy this application, see the [contacts-mobile-proxy README](server/contacts-mobile-proxy/README.md) file.
+* [contacts-mobile-proxy](server/contacts-mobile-proxy/README.md) layers the `push-contacts-mobile-picketlink-secured` quickstart and it can only be used in conjunction with the latter. It is intended for use when the `push-contacts-mobile-picketlink-secured` application is deployed on a server that is protected behind a firewall, preventing access by clients outside the firewall. The `contacts-mobile-proxy` is deployed on a server outside the firewall to act as a proxy or router application. This application has an accessible user interface, in which contacts can be viewed and managed as in the client applications. Note that this application has no push functionality. 
 
 
 ### Client-side Applications
 
 The source for the client applications is located in the `QUICKSTART_HOME/push-contacts-mobile/client` directory. This project provides a variety of client applications to demonstrate different mobile APIs and traditional web access.
 
-* `push-contacts-mobile-android`, `push-contacts-mobile-ios`, and `push-contacts-mobile-cordova` are implementations of the same client application for different mobile APIs. When the client application is deployed to a mobile device, the push functionality enables the device to register with the JBoss Unified Push Server and receive push notifications when new contacts are created. The client applications are secured and authentication managed by `push-contacts-mobile-picketlink-secured`. Additionally, all contact data for the client applications is sourced from the server-side application. For information on how to deploy these applications, see the individual README files at the following links:
+* [push-contacts-mobile-android](client/push-contacts-mobile-android/README.md), [push-contacts-mobile-ios](client/push-contacts-mobile-ios/README.md), and [push-contacts-mobile-cordova](client/push-contacts-mobile-cordova/README.md) are implementations of the same client application for different mobile APIs. When the client application is deployed to a mobile device, the push functionality enables the device to register with the JBoss Unified Push Server and receive push notifications when new contacts are created. The client applications are secured and authentication managed by the server-side `push-contacts-mobile-picketlink-secured` application. Additionally, all contact data for the client applications is sourced from the server-side application. 
 
-  * [push-contacts-mobile-android README](client/push-contacts-mobile-android/README.md)
-  * [push-contacts-mobile-ios README](client/push-contacts-mobile-ios/README.md)
-  * [push-contacts-mobile-cordova README](client/push-contacts-mobile-cordova/README.md)
-
-
-* `contacts-mobile-webapp` is an implementation of the client application for deployment to a server rather than a mobile device. Like the mobile client applications, this application requires authentication to view and manage contacts. But this application has no push functionality; it does not register with the Unified Push Server on deployment and it does not receive push notifications when contacts are created by other client applications. For information on how to deploy this application, see the [contacts-mobile-webapp README](client/contacts-mobile-webapp/README.md) file.
+* [contacts-mobile-webapp](client/contacts-mobile-webapp/README.md) is an implementation of the client application for deployment to a server rather than a mobile device. Like the mobile client applications, this application requires authentication to view and manage contacts. But this application has no push functionality; it does not register with the Unified Push Server on deployment and it does not receive push notifications when contacts are created by other client applications. 
 
 For information about JBoss Unified Push, see the [JBoss Unified Push documentation](https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Unified_Push/).
+

--- a/push-contacts-mobile/client/contacts-mobile-webapp/README.md
+++ b/push-contacts-mobile/client/contacts-mobile-webapp/README.md
@@ -9,6 +9,7 @@ Versions: 1.0
 Source: <https://github.com/jboss-developer/jboss-mobile-quickstarts/>  
 
 ## What is it?
+
 It's a deployable Maven 3 project to help you get started in developing HTML5 based mobile web applications on JBoss EAP. This project is set up to allow you to create a basic Java EE 6 application using HTML5 and jQuery Mobile.
 
 This application is built using HTML5. This uses a pure HTML client that interacts with the application server via restful end-points (JAX-RS). This application also uses some of the latest HTML5 features. And since testing is just as important with client side as it is with server side, this application uses QUnit to show you how to unit test your JavaScript.
@@ -28,7 +29,8 @@ In addition, there are [qunit tests](#run-the-qunit-tests) for every form of val
 
 ## How do I use it?
 
-###0. System Requirements
+### 0. System Requirements
+
 * [Java 6](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
 * [Maven 3.0](http://maven.apache.org) or later
 * Red Hat JBoss Enterprise Application Platform (EAP) 6.3.0.GA
@@ -38,58 +40,62 @@ In addition, there are [qunit tests](#run-the-qunit-tests) for every form of val
 
 Mobile web support is limited to Android and iOS devices.
 
-###1. Prepare Maven Libraries
+### 1. Prepare Maven Libraries
+
 This quickstart is designed to be built with Maven. It requires the JBoss Unified Push and JBoss EAP 6.3.0 Maven repositories.
 
 You must have the JBoss Unified Push Maven repository available and Maven configured to use it. For more information, see the [JBoss Unified Push documentation](https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Unified_Push/) or the README distributed with the JBoss Unified Push Maven repository.
 
 
-###2. Start the JBoss EAP Server
+### 2. Start the JBoss EAP Server
 1. Open a command line and navigate to the root of the JBoss EAP directory.
 2. The following shows the command line to start the server with the default profile:
-```shell
-For Linux:   EAP_HOME/bin/standalone.sh
-For Windows: EAP_HOME\bin\standalone.bat
-```
+
+        For Linux:   EAP_HOME/bin/standalone.sh
+        For Windows: EAP_HOME\bin\standalone.bat
+
 
 **Note:** Adding "-b 0.0.0.0" to the above commands will allow external clients (phones, tablets, desktops, etc...) to connect through your local network.
 
 For example
-```shell
-For Linux:   EAP_HOME/bin/standalone.sh -b 0.0.0.0
-For Windows: EAP_HOME\bin\standalone.bat -b 0.0.0.0
-```
+
+        For Linux:   EAP_HOME/bin/standalone.sh -b 0.0.0.0
+        For Windows: EAP_HOME\bin\standalone.bat -b 0.0.0.0
+
 
 If you are running multiple servers on the same machine you can use `jboss.socket.binding.port-offset` to avoid port conflicts:
-```shell
-For Linux:   EAP_HOME/bin/standalone.sh -b 0.0.0.0 -Djboss.socket.binding.port-offset=1000
-For Windows: EAP_HOME\bin\standalone.bat -b 0.0.0.0 -Djboss.socket.binding.port-offset=1000
-```
-###3. Configure the REST API server
+
+        For Linux:   EAP_HOME/bin/standalone.sh -b 0.0.0.0 -Djboss.socket.binding.port-offset=1000
+        For Windows: EAP_HOME\bin\standalone.bat -b 0.0.0.0 -Djboss.socket.binding.port-offset=1000
+
+### 3. Configure the REST API server
+
 This web application can be configured to use the `push-contacts-mobile-picketlink-secured` or the `contacts-mobile-proxy` as the backend REST API.
 To switch between backends update `CONTACTS.app.serverUrl` in `src/main/webapp/js/app.js`:
-```java
-CONTACTS.app.serverUrl = "http://localhost:9080/jboss-push-contacts-mobile-picketlink-secured";
-```
+
+        CONTACTS.app.serverUrl = "http://localhost:9080/jboss-push-contacts-mobile-picketlink-secured";
+
 or
-```java
-CONTACTS.app.serverUrl = "http://localhost:8080/jboss-contacts-mobile-proxy";
-```
+
+        CONTACTS.app.serverUrl = "http://localhost:8080/jboss-contacts-mobile-proxy";
+
 
 **Note:** the port numbers above might be different for your current setup.
 
 Please refer to the documentation for [push-contacts-mobile-picketlink-secured](../../server/push-contacts-mobile-picketlink-secured) and [contacts-mobile-proxy](../../server/contacts-mobile-proxy) for details about deploying these quickstarts.
 
-###4. Build and Deploy the Quickstart
+### 4. Build and Deploy the Quickstart
+
 1. Make sure you have started the JBoss EAP server as described above.
 2. Open a command line and navigate to the root directory of this quickstart.
 3. Type this command to build and deploy the archive:
-```shell
-mvn clean package jboss-as:deploy
-```
+
+        mvn clean package jboss-as:deploy
+
 4. This deploys `target/jboss-contacts-mobile-webapp.war` to the running instance of the server.
 
-###5. Test Application
+### 5. Test the Application
+
 Access the running client application in a browser at the following URL: <http://localhost:8080/jboss-contacts-mobile-webapp/>. You can use one of the default user credentials ('_maria:maria_','_dan:dan_', or '_john:john_').
 The app is made up of the following pages:
 
@@ -124,14 +130,13 @@ The app is made up of the following pages:
 * Same as Add form
 * Delete button will delete the contact currently viewed and return you to the Main page
 
-###6. Undeploy the Quickstart
+### 6. Undeploy the Quickstart
 
 1. Make sure you have started the JBoss EAP server as described above.
 2. Open a command line and navigate to the root directory of this quickstart.
 3. When you are finished testing, type this command to undeploy the archive:
-```shell
-mvn jboss-as:undeploy
-```
+
+        mvn jboss-as:undeploy
 
 ## FAQ
 
@@ -144,6 +149,7 @@ Why can't I enter a date in the birthdate field?
   
 
 ## Minification
+
 By default, the project uses the [wro4j](http://code.google.com/p/wro4j/) plugin, which provides the ability to concatenate, validate and minify JavaScript and CSS files. These minified files, as well as their unmodified versions are deployed with the project.  
 
 With just a few quick changes to the project, you can link to the minified versions of your JavaScript and CSS files.  
@@ -152,17 +158,18 @@ First, in the `<project-root>/src/main/webapp/index.html` file, search for refer
 
 Finally, wro4j runs in the compile phase so any standard build command like package, install, etc. will trigger it.  
 The plugin is in a profile with an id of `minify` so you will want to specify that profile in your maven build. For example:
-```shell
-mvn clean package jboss-as:deploy -Pminify,default
-```
+
+        mvn clean package jboss-as:deploy -Pminify,default
+
 
 ## Run the QUnit tests
+
 QUnit is a JavaScript unit testing framework used and built by jQuery. Because JavaScript code is the core of this HTML5 application, this quickstart provides a set of QUnit tests that automate testing of this code in various browsers. Executing QUnit test cases are quite easy.  
 
 Simply load the following HTML in the browser you wish to test.
-```
-QUICKSTART_HOME/push-contacts-mobile/client/contacts-mobile-webapp/src/test/qunit/index.html
-```
+
+        QUICKSTART_HOME/push-contacts-mobile/client/contacts-mobile-webapp/src/test/qunit/index.html
+
 **Note:** If you use `Chrome`, some date tests fail. These are false failures and are known issues with Chrome. FireFox, Safari, and IE run the tests correctly.
 
 You can also display the tests using the Eclipse built-in browser.
@@ -170,14 +177,12 @@ You can also display the tests using the Eclipse built-in browser.
 For more information on QUnit tests see http://docs.jquery.com/QUnit
 
 ## Use the Project with an IDE
+
 You can import this project into an IDE (JBoss Developer Studio, NetBeans or IntelliJ IDEA). If you are using JBoss Developer Studio you must import the project as a Maven project. If you are using NetBeans 6.8 or IntelliJ IDEA 9, then you can open the project as an existing project as both of these IDEs recognize Maven projects natively.
 
 You can also start the server and deploy the quickstarts from JBoss Developer Studio. For more information , see the [Get Started with JBoss Developer Studio](http://www.jboss.org/products/devstudio/get-started/ "Get Started with JBoss Developer Studio").
 
-If you want to be able to debug into the source code or look at the Javadocs of any library in the project, you can run either of the following two commands to pull them into your local repository. The IDE should then detect them.
+If you want to debug the source code of any library in the project, run the following command to pull the source into your local repository. The IDE should then detect it.
 
-```shell
-$ mvn dependency:sources
-$ mvn dependency:resolve -Dclassifier=javadoc
-```
+    mvn dependency:sources
 

--- a/push-contacts-mobile/client/push-contacts-mobile-android/README.md
+++ b/push-contacts-mobile/client/push-contacts-mobile-android/README.md
@@ -4,6 +4,7 @@ Author: Daniel Passos (dpassos)
 Level: Intermediate  
 Technologies: Java, Android  
 Summary: A contacts CRUD mobile application with push notification integration.  
+Prerequisites: push-contacts-mobile-picketlink-secured  
 Target Product: JBoss Unified Push  
 Versions: 1.0  
 Source: <https://github.com/jboss-developer/jboss-mobile-quickstarts/>  
@@ -18,13 +19,15 @@ When the client application is deployed to an Android device, the push functiona
 
 ## How do I run it?
 
-###0. System requirements
+### 0. System requirements
+
 * [Java 7](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
 * [Maven 3.1.1](http://maven.apache.org)
 * Latest [Android SDK](https://developer.android.com/sdk/index.html) and [Platform version 19](http://developer.android.com/tools/revisions/platforms.html)
 * Latest [Android Support Library](http://developer.android.com/tools/support-library/index.html) and [Google Play Services](http://developer.android.com/google/play-services/index.html)
 
-###1. Prepare Maven Libraries
+### 1. Prepare Maven Libraries
+
 This quickstart is designed to be built with Maven. It requires the JBoss Unified Push Maven repository and Google libraries.
 
 You must have the JBoss Unified Push Maven repository available and Maven configured to use it. For more information, see the [JBoss Unified Push documentation](https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Unified_Push/) or the README distributed with the JBoss Unified Push Maven repository.
@@ -32,32 +35,33 @@ You must have the JBoss Unified Push Maven repository available and Maven config
 Google does not ship all the required libraries to Maven Central so you must deploy them locally with the helper utility [maven-android-sdk-deployer](https://github.com/mosabua/maven-android-sdk-deployer) as detailed here.
 
 1. Checkout maven-android-sdk-deployer
-```shell
-$ git clone git://github.com/mosabua/maven-android-sdk-deployer.git
-```
+
+        git clone git://github.com/mosabua/maven-android-sdk-deployer.git
+
 2. Set up the environment variable `ANDROID_HOME` to contain the Android SDK path
 3. Install Maven version of Android platform 19
-```shell
-$ cd /path/to/maven-android-sdk-deployer/platforms/android-19
-$ mvn install -N
-```
-4. Install Maven version of google-play-services
-```shell
-$ cd /path/to/maven-android-sdk-deployer/extras/google-play-services
-$ mvn install -N
-```
-5. Install Maven version of compatibility-v4
-```shell
-$ cd /path/to/maven-android-sdk-deployer/extras/compatibility-v4
-$ mvn install -N
-```
-6. Install Maven version of compatibility-v7-appcompat
-```shell
-$ cd /path/to/maven-android-sdk-deployer/extras/compatibility-v7-appcompat
-$ mvn install -N
-```
 
-###2. Register Application with Push Services
+        cd /path/to/maven-android-sdk-deployer/platforms/android-19
+        mvn install -N
+
+4. Install Maven version of google-play-services
+
+        cd /path/to/maven-android-sdk-deployer/extras/google-play-services
+        mvn install -N
+
+5. Install Maven version of compatibility-v4
+
+        cd /path/to/maven-android-sdk-deployer/extras/compatibility-v4
+        mvn install -N
+
+6. Install Maven version of compatibility-v7-appcompat
+
+        cd /path/to/maven-android-sdk-deployer/extras/compatibility-v7-appcompat
+        mvn install -N
+
+
+### 2. Register Application with Push Services
+
 First, you must register the application with Google Cloud Messaging for Android and enable access to the Google Cloud Messaging for Android APIs and Google APIs. This ensures access to the APIs by the Unified Push Server when it routes push notification requests from the application to the GCM. Registering an application with GCM requires that you have a Google account.
 
 1. Log into the [Google Cloud Console](https://console.developers.google.com)
@@ -80,40 +84,44 @@ Second, you must register the application and an Android variant of the applicat
 8. Click `Add`.
 9. When created, expand the variant name and make note of the `Server URL`, `Variant ID`, and `Secret`.
 
-###3. Customize and Build Application
+### 3. Customize and Build Application
+
 The project source code must be customized with the unique metadata assigned to the application variant by the Unified Push Server and GCM. 
 
 1. Open `QUICKSTART_HOME/push-contacts-mobile/client/push-contacts-mobile-android/src/org/jboss/aerogear/unifiedpush/quickstart/Constants.java` for editing.
 2. Enter the application variant values allocated by the Unified Push Server and GCM for the following constants:
-```java
-String UNIFIED_PUSH_URL = "";
-String VARIANT_ID = "";
-String SECRET = "";
-String GCM_SENDER_ID = "";
-```
+
+        String UNIFIED_PUSH_URL = "";
+        String VARIANT_ID = "";
+        String SECRET = "";
+        String GCM_SENDER_ID = "";
+
 3. Save the file.
 4. Build the application
-```shell
-$ cd QUICKSTART_HOME/push-contacts-mobile/client/push-contacts-mobile-android
-$ mvn compile
-```
 
-###4. Test Application
+        cd QUICKSTART_HOME/push-contacts-mobile/client/push-contacts-mobile-android
+        mvn compile
 
-####0. Prerequisites
+
+### 4. Test the Application
+
+#### 0. Prerequisites
+
 1. The Unified Push Server must be running before the application is deployed to ensure that the device successfully registers with the Unified Push Server on application deployment.
 2. The `push-contacts-mobile/server/push-contacts-mobile-picketlink-secured` application must be running before attempting to log into the mobile client application to ensure successful login. For more information, see the README distributed with the `push-contacts-mobile-picketlink-secured` application.
 
-####1. Deploy for Testing
+#### 1. Deploy for Testing
+
 The application can be tested on physical Android devices only; push notifications are not available for Android emulators. To deploy, run and debug the application on an Android device attached to your system, on the command line enter the following:
-```shell
-$ cd QUICKSTART_HOME/push-contacts-mobile/client/push-contacts-mobile-android
-$ mvn clean package android:deploy android:run
-```
+
+        cd QUICKSTART_HOME/push-contacts-mobile/client/push-contacts-mobile-android
+        mvn clean package android:deploy android:run
+
 
 Application output is displayed in the command line window.
 
-####2. Log In
+#### 2. Log In
+
 When the application is deployed to an Android device, you can log into it and begin using the CRUD functionality. Note that access to the application is restricted to users registered with the server-side application and to assist you in getting started a number of default users are preconfigured.
 
 1. Launch the application on the Android device.
@@ -127,7 +135,8 @@ When the application is deployed to an Android device, you can log into it and b
 
 	![contact details](doc/contact-details.png)
 
-####3. Send a Push Message
+#### 3. Send a Push Message
+
 You can send a push notification to your device by creating a new Contact.  
 You can also send a push notification to your device using the `push-contacts-mobile/client/contacts-mobile-webapp` application by completing the following steps (for more information, see the README distributed with the `contacts-mobile-webapp` application):
 

--- a/push-contacts-mobile/client/push-contacts-mobile-cordova/README.md
+++ b/push-contacts-mobile/client/push-contacts-mobile-cordova/README.md
@@ -19,62 +19,70 @@ When the client application is deployed to an Android or iOS device, the push fu
 
 ## How do I run it?
 
-###0. System requirements
+### 0. System requirements
+
 The Cordova command line tooling is based on node.js so first you'll need to [install node](http://nodejs.org/download/), then you can install Cordova by executing:
-```shell
-npm install -g cordova
-```
+
+        npm install -g cordova
+
 
 To deploy on iOS you need to install the ios-deploy package as well
-```shell
-npm install -g ios-deploy
-```
+
+        npm install -g ios-deploy
+
 
 #### iOS
+
 For iOS you'll need a valid provisioning profile as you will need to test on an actual device (push notification is not available when using a simulator).
 Replace the bundleId with your bundleId (the one associated with your certificate), by editing the config.xml at the root of this project, change the id attribute of the `widget` node. After that run a `cordova platform rm ios` followed by `cordova platform add ios` to change the Xcode project template.
 
 If you want to change your bundleId later on, you will still have to run a `cordova platform rm ios` followed by `cordova platform add ios` to change the Xcode project template.
 
 #### Android
+
 To deploy and run Cordova applications on Android the Apache Ant tool needs to be [installed](http://ant.apache.org/manual/install.html).
 
-###1. Register Application with Push Services
+### 1. Register Application with Push Services
 
 For the configuration and registration of Android or iOS Applications with PushServices, please refer to the specific guides inside *push-contacts-mobile-android* and *push-contacts-mobile-ios* quickstarts.
 
-###2. Customize and Build Application
+### 2. Customize and Build Application
 
 There are 2 examples for Cordova; one is built using [jquery mobile](jqm) and one with [angular](angular). The READMEs located in these directories will direct you to the settings you'll need to change to setup push notifications.
 
-###3. Install platforms
+### 3. Install platforms
 
 After changing the push configuration you can install the platforms you want on the Cordova app. JBoss Unified Push for Cordova currently supports Android and iOS.
-```shell
-cordova platform add <android or ios>
-```
 
-###4. Add JBoss Unified Push Cordova Push plug-in
+        cordova platform add <android or ios>
+
+
+### 4. Add JBoss Unified Push Cordova Push plug-in
+
 You now need to add the plugin to the Cordova app.
-```shell
-cordova plugin add `QUICKSTART_HOME/push-contacts-mobile/client/push-contacts-mobile-cordova/cordova_pushplugin/org.jboss.aerogear.cordova.push`
-```
 
-###5. Test Application
+        cordova plugin add `QUICKSTART_HOME/push-contacts-mobile/client/push-contacts-mobile-cordova/cordova_pushplugin/org.jboss.aerogear.cordova.push`
 
-####0. Prerequisites
+
+### 5. Test the Application
+
+#### 0. Prerequisites
+
 1. The Unified Push Server must be running before the application is deployed to ensure that the device successfully registers with the Unified Push Server on application deployment.
 2. The `push-contacts-mobile/server/push-contacts-mobile-picketlink-secured` application must be running before attempting to log into the mobile client application to ensure successful login. For more information, see the README distributed with the `push-contacts-mobile-picketlink-secured` application.
 
-####1. Deploy for Testing
+#### 1. Deploy for Testing
+
 The application can be tested on physical Android or iOS devices only; push notifications are not available for Android emulators nor iOS simulators. To deploy, run and debug the application on an Android or iOS device attached to your system, on the command line enter the following:
-```shell
-cordova run <android or ios>
-```
-####2. Log In
+
+        cordova run <android or ios>
+
+#### 2. Log In
+
 For the _Log In_ procedure on Android or iOS devices, please refer to the specific guides inside *push-contacts-mobile-android* and *push-contacts-mobile-ios* quickstarts.
 
-####3. Send a Push Message
+#### 3. Send a Push Message
+
 For the _Send a Push Message_ procedure on Android or iOS devices, please refer to the specific guides inside *push-contacts-mobile-android* and *push-contacts-mobile-ios* quickstarts.
 
 
@@ -104,12 +112,16 @@ Run the project on a device:
 Debug the Application
 =====================
 
-Start a browser Chrome for Android or Safari for iOS
+1. Start a browser Chrome for Android or Safari for iOS
 
-iOS
-* Develop -> &lt;device name> -> index.html
+2. Follow the instructions for the mobile device
 
-Android
-* Menu -> Tools -> Inspect Devices -> inspect
+   * For iOS
+
+        Develop -> &lt;device name> -> index.html
+
+   * For Android
+
+        Menu -> Tools -> Inspect Devices -> inspect
 
 

--- a/push-contacts-mobile/client/push-contacts-mobile-cordova/angular/README.md
+++ b/push-contacts-mobile/client/push-contacts-mobile-cordova/angular/README.md
@@ -1,31 +1,31 @@
-###3. Customize and Build Application for Angular
+### 3. Customize and Build Application for Angular
 
 Please first refer to the Cordova guide located in this [README](../README.md)
 
 * In `www/js/controllers.js` find the _pushConfig_ (at the top) and change _pushServerURL_ with the url of your Unified Push Server instance. You also need to change _senderID_, _variantID_ and _variantSecret_ with the values assigned by Unified Push Server and GCM or APNS:
 
-```javascript
-var pushConfig = {
-   pushServerURL: "<pushServerURL e.g http(s)//host:port/context >",
-   android: {
-      senderID: "<senderID e.g Google Project ID only for android>",
-      variantID: "<variantID e.g. 1234456-234320>",
-      variantSecret: "<variantSecret e.g. 1234456-234320>"
-   },
-   ios: {
-      variantID: "<variantID e.g. 1234456-234320>",
-      variantSecret: "<variantSecret e.g. 1234456-234320>"
-   }
-};
 
-```
+        var pushConfig = {
+           pushServerURL: "<pushServerURL e.g http(s)//host:port/context >",
+           android: {
+              senderID: "<senderID e.g Google Project ID only for android>",
+              variantID: "<variantID e.g. 1234456-234320>",
+              variantSecret: "<variantSecret e.g. 1234456-234320>"
+           },
+           ios: {
+              variantID: "<variantID e.g. 1234456-234320>",
+              variantSecret: "<variantSecret e.g. 1234456-234320>"
+           }
+        };
+
+
 **Note:** You can also copy/paste these settings from your Unified Push Server console
 
 * In `www/js/app.js` change the value of _BACKEND_URL_ with the url of your Unified Push Server instance. Use `ip` or `hostname` and not `localhost` for the `host` value:
 
-```javascript
-//app.js    
-.constant('BACKEND_URL','< backend URL e.g http(s)//host:port >/jboss-push-contacts-mobile-picketlink-secured/')
-```
+
+        //app.js    
+        .constant('BACKEND_URL','< backend URL e.g http(s)//host:port >/jboss-push-contacts-mobile-picketlink-secured/')
+
 
 **Important:** Make sure that the Unified Push Server instance can be reached from your device (start the JBoss EAP server with the parameters `-b 0.0.0.0`).

--- a/push-contacts-mobile/client/push-contacts-mobile-cordova/cordova_pushplugin/org.jboss.aerogear.cordova.push/README.md
+++ b/push-contacts-mobile/client/push-contacts-mobile-cordova/cordova_pushplugin/org.jboss.aerogear.cordova.push/README.md
@@ -5,77 +5,80 @@
 
 ## How do I use it?
 
-###0. System Requirements
+### 0. System Requirements
 
 * [Apache Cordova CLI](https://github.com/apache/cordova-cli/)
 * [Node.js](http://nodejs.org/download/)
 * Install Cordova by executing:
-  ```shell
-  $ npm install -g cordova
-  ```
-  To deploy on iOS you need to install also the ios-deploy package:
-  ```shell
-  npm install -g ios-deploy
-  ```
 
-###1. Pre-requisites
+        npm install -g cordova
+
+  To deploy on iOS you need to install also the ios-deploy package:
+
+        npm install -g ios-deploy
+
+
+### 1. Prerequisites
 
 Before building the application, you must register the Android or iOS variant of the application with a running JBoss Unified Push Server instance and Google Cloud Messaging for Android or Apple Push Notification Service for iOS. The resulting unique IDs and other parameters must then be inserted into the application source code. After this is complete, the application can be built and deployed to Android or iOS devices.
 
 For the configuration and registration of Android or iOS Applications with GCM or APNS, please refer to the specific guides inside `JBoss Unified Push for Android` and `JBoss Unified Push for iOS` libraries.
 
-###2. Use JBoss Unified Push PushPlugin for Cordova
+### 2. Use JBoss Unified Push PushPlugin for Cordova
 
 Extract the `JBoss Unified Push PushPlugin for Cordova` and install it specifying the local path to the plugin directory that contains the `plugin.xml` file, executing the following command from within your project folder:
-```shell
-cordova plugin add <path-to-org.jboss.aerogear.cordova.push-dir>
-```
+
+        cordova plugin add <path-to-org.jboss.aerogear.cordova.push-dir>
+
 
 Done! Your project now contains the JBoss Unified Push PushPlugin. For an integration with the `JBoss Unified Push Server` open the `www` folder in your text editor and apply the code from the example below. You can then execute the project with the command:
-```shell
-cordova run <android or ios>
-```
-## Example Usage
-###1. Register the application
-The following JavaScript code shows how to register a device with the JBoss Unified Push Server. You need to change `pushServerURL` with the url of your Unified Push Server instance. You also need to change `senderID`, `variantID` and `variantSecret` with the values assigned by Unified Push Server and GCM or APNS:
-```
-var pushConfig = {
-    pushServerURL: "<pushServerURL e.g http(s)//host:port/context >",
-    alias: "<alias e.g. a username or an email address optional>",
-    android: {
-      senderID: "<senderID e.g Google Project ID only for android>",
-      variantID: "<variantID e.g. 1234456-234320>",
-      variantSecret: "<variantSecret e.g. 1234456-234320>"
-    },
-    ios: {
-      variantID: "<variantID e.g. 1234456-234320>",
-      variantSecret: "<variantSecret e.g. 1234456-234320>"
-    }
-};
 
-push.register(onNotification, successHandler, errorHandler, pushConfig);
-```
+        cordova run <android or ios>
+
+## Example Usage
+
+### 1. Register the application
+
+The following JavaScript code shows how to register a device with the JBoss Unified Push Server. You need to change `pushServerURL` with the url of your Unified Push Server instance. You also need to change `senderID`, `variantID` and `variantSecret` with the values assigned by Unified Push Server and GCM or APNS:
+
+        var pushConfig = {
+            pushServerURL: "<pushServerURL e.g http(s)//host:port/context >",
+            alias: "<alias e.g. a username or an email address optional>",
+            android: {
+              senderID: "<senderID e.g Google Project ID only for android>",
+              variantID: "<variantID e.g. 1234456-234320>",
+              variantSecret: "<variantSecret e.g. 1234456-234320>"
+            },
+            ios: {
+              variantID: "<variantID e.g. 1234456-234320>",
+              variantSecret: "<variantSecret e.g. 1234456-234320>"
+            }
+        };
+        
+        push.register(onNotification, successHandler, errorHandler, pushConfig);
+
 
 If you are only targeting one platform, you can simplify the code above by:
 
-```
-var pushConfig = {
-    pushServerURL: "<pushServerURL e.g http(s)//host:port/context >",
-    alias: "<alias e.g. a username or an email address optional>",
-    variantID: "<ios variantID e.g. 1234456-234320>",
-    variantSecret: "<ios variantSecret e.g. 1234456-234320>"
-};
 
-push.register(onNotification, successHandler, errorHandler, pushConfig);
-```
+        var pushConfig = {
+            pushServerURL: "<pushServerURL e.g http(s)//host:port/context >",
+            alias: "<alias e.g. a username or an email address optional>",
+            variantID: "<ios variantID e.g. 1234456-234320>",
+            variantSecret: "<ios variantSecret e.g. 1234456-234320>"
+        };
+        
+        push.register(onNotification, successHandler, errorHandler, pushConfig);
 
-###2. Receive Remote Notifications
+
+### 2. Receive Remote Notifications
+
 The `onNotification` callback will get executed by the plugin when a new message arrives. 
-```
-function onNotification(event) {
-    alert(event.alert);
-}
-```
+
+        function onNotification(event) {
+            alert(event.alert);
+        }
+
 
 The passed in `event` object contains:
 
@@ -86,37 +89,40 @@ The passed in `event` object contains:
 
 
 #### iOS Background Notification
+
 Sending notifications that contain `content-available` on iOS will call the JavaScript before launching the application. This will enable you to update the UI or do a silent push (e.g. without an alert) to update the content of your application without the user noticing.  After fetching the content, you'll have to _inform_ the os about the result by calling `setContentAvailable` with either `NewData`, `NoData` or `Failed`:
 
-```
-function onNotification(event) {
 
-  if (event['content-available'] === 1) {
-    if (!event.foreground) {
-      // fetch content
-      push.setContentAvailable(push.FetchResult.NewData);
-    }
-  }
-}
-```
+        function onNotification(event) {
+        
+          if (event['content-available'] === 1) {
+            if (!event.foreground) {
+              // fetch content
+              push.setContentAvailable(push.FetchResult.NewData);
+            }
+          }
+        }
 
-###3. Unregister the Application (only available on Android):
 
-```
-push.unregister(successHandler, errorHandler);
+### 3. Unregister the Application (only available on Android):
 
-function successHandler() {
-    console.log('success')
-}
 
-function errorHandler(message) {
-    console.log('error ' + message);
-}
-```
+        push.unregister(successHandler, errorHandler);
+
+        function successHandler() {
+            console.log('success')
+        }
+
+        function errorHandler(message) {
+            console.log('error ' + message);
+        }
+
 
 ## Demo
+
 For more information about configuring and using the JBoss Unified Push PushPlugin for Cordova, refer to `JBoss Unified Push Helloworld Cordova` and `JBoss Unified Push Contacts Mobile Cordova`, as examples of projects using the push feature with JBoss Unified Push for Cordova.
 
 ###JBoss Unified Push Server
+
 For more information about deploying, configuring and using the JBoss Unified Push Server, see the [JBoss Unified Push documentation](https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Unified_Push/).
 

--- a/push-contacts-mobile/client/push-contacts-mobile-cordova/jqm/README.md
+++ b/push-contacts-mobile/client/push-contacts-mobile-cordova/jqm/README.md
@@ -1,31 +1,31 @@
-###3. Customize and Build Application for JQuery Mobile
+### 3. Customize and Build Application for JQuery Mobile
 
 Please first refer to the Cordova guide located in this [README](../README.md)
 
 * In `www/js/app.js` find the _pushConfig_ (at the bottom) and change _pushServerURL_ with the url of your Unified Push Server instance. You also need to change _senderID_, _variantID_ and _variantSecret_ with the values assigned by Unified Push Server and GCM or APNS:
 
-```javascript
-var pushConfig = {
-   pushServerURL: "<pushServerURL e.g http(s)//host:port/context >",
-   alias: "<alias e.g. a username or an email address optional>",
-   android: {
-      senderID: "<senderID e.g Google Project ID only for android>",
-      variantID: "<variantID e.g. 1234456-234320>",
-      variantSecret: "<variantSecret e.g. 1234456-234320>"
-   },
-   ios: {
-      variantID: "<variantID e.g. 1234456-234320>",
-      variantSecret: "<variantSecret e.g. 1234456-234320>"
-   }
-};
-```
+
+        var pushConfig = {
+           pushServerURL: "<pushServerURL e.g http(s)//host:port/context >",
+           alias: "<alias e.g. a username or an email address optional>",
+           android: {
+              senderID: "<senderID e.g Google Project ID only for android>",
+              variantID: "<variantID e.g. 1234456-234320>",
+              variantSecret: "<variantSecret e.g. 1234456-234320>"
+           },
+           ios: {
+              variantID: "<variantID e.g. 1234456-234320>",
+              variantSecret: "<variantSecret e.g. 1234456-234320>"
+           }
+        };
+
 **Note:** You can also copy/paste these settings from your Unified Push Server console
 
 * In `www/js/app.js` change the value of _CONTACTS.app.baseUrl_ with the url of your Unified Push Server instance. Use `ip` or `hostname` and not `localhost` for the `host` value:
 
-```javascript
-//app.js
-CONTACTS.app.baseUrl = "< backend URL e.g http(s)//host:port >/jboss-push-contacts-mobile-picketlink-secured/";
-```
+
+        //app.js
+        CONTACTS.app.baseUrl = "< backend URL e.g http(s)//host:port >/jboss-push-contacts-mobile-picketlink-secured/";
+
 
 **Important:** Make sure that the Unified Push Server instance can be reached from your device (start the JBoss EAP server with the parameters `-b 0.0.0.0`).

--- a/push-contacts-mobile/client/push-contacts-mobile-ios/README.md
+++ b/push-contacts-mobile/client/push-contacts-mobile-ios/README.md
@@ -18,11 +18,12 @@ When the client application is deployed to an iOS device, the push functionality
 
 ## How do I run it?
 
-###0. System requirements
+### 0. System requirements
+
 * iOS 7.X
 * Xcode version 5.1.X
 
-###1. Configuration
+### 1. Configuration
 
 #### Creation of Certificate Signing Request and SSL certificate for APNs
 
@@ -43,7 +44,7 @@ In order to test Push Notifications you neeed to create a _Provisioning Profile_
   *  `Development Provisioning Profile`: In the _Provisioning Portal_ you need to create an _iOS App Development_ provisioning profile, so that you can test the Push Notifications on your own iOS devices. Select the `App ID` that you created earlier and your _Developer Certificate_. Select a _Test_ Device, give it a Profile Name and generate it. Now download the Profile and open the file. Go to `Xcode -> preferences...` menu, select the `Account` tab, on the right bottom corner click `View details...` and you should see your provisioning profile.
   *  `Distribution Provisioning Profile`: In order to test Push Notifications on a `production environment`, you need to create an _iOS App Distribution_ provisioning profile in the _Provisioning Portal_. Select the `App ID`, that you created earlier and your _Production Certificate_. You still need a _test device_ to try your _production_ app with your _distribution provisioning profile_. Select a _Test_ Device, give it a Profile Name and generate it. Now download the Profile and open the file. Go to `Xcode -> preferences...` menu, select the `Account` tab, on the right bottom corner click `View details...` and you should see your provisioning profile.
   
-###2. Register Application with Push Services
+### 2. Register Application with Push Services
 
 You must register the application and an iOS variant of the application with the Unified Push Server. This requires a running Unified Push Server instance and uses the unique metadata assigned to the application by APNS. For information on installing the Unified Push Server, see the [JBoss Unified Push documentation](https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Unified_Push/).
 
@@ -58,7 +59,7 @@ You must register the application and an iOS variant of the application with the
 9. When created, expand the variant name and make note of the `Server URL`, `Variant ID`, and `Secret`.
 
 
-###3. Customize and Build Application
+### 3. Customize and Build Application
 
 Replace the bundleId with your bundleId (the one associated with your certificate).
 Click on the `Contacts target -> General` and modify the _Bundle Identifier_:
@@ -73,32 +74,35 @@ The project source code must be customized with the unique metadata assigned to 
 
 1. Open `QUICKSTART_HOME/push-contacts-mobile/client/push-contacts-mobile-ios/Contacts/Controllers/AGLoginViewController.m` for editing.
 2. Modify the URL, variant and secret to match the values allocated by the Unified Push Server and APNS for the following constants:
-```objective-c
-AGDeviceRegistration *registration = [[AGDeviceRegistration alloc] initWithServerURL:[NSURL URLWithString:@"<# URL of the running Unified Push Server #>"]];
-...
-[clientInfo setVariantID:@"<# Variant Id #>"];
-[clientInfo setVariantSecret:@"<# Variant Secret #>"];
-```
+
+        AGDeviceRegistration *registration = [[AGDeviceRegistration alloc] initWithServerURL:[NSURL URLWithString:@"<# URL of the running Unified Push Server #>"]];
+        ...
+        [clientInfo setVariantID:@"<# Variant Id #>"];
+        [clientInfo setVariantSecret:@"<# Variant Secret #>"];
+
 **Note:** You can also copy/paste these settings from your Unified Push Server console
 3. Save the file.
 4. Open `QUICKSTART_HOME/push-contacts-mobile/client/push-contacts-mobile-ios/Contacts/Networking/AGContactsNetworker.m` for editing.
 5. Modify the URL to match the path to the Contacts server backend:
-```objective-c
-static NSString * const kAPIBaseURLString = @"<# URL of the Contacts application backend #>";
-```
+
+        static NSString * const kAPIBaseURLString = @"<# URL of the Contacts application backend #>";
+
 6. Save the file.
 7. Build the application
 
-###4. Test Application
+### 4. Test the Application
 
-####0. Prerequisites
+#### 0. Prerequisites
+
 1. The Unified Push Server must be running before the application is deployed to ensure that the device successfully registers with the Unified Push Server on application deployment.
 2. The `push-contacts-mobile/server/push-contacts-mobile-picketlink-secured` application must be running before attempting to log into the mobile client application to ensure successful login. For more information, see the README distributed with the `push-contacts-mobile-picketlink-secured` application.
 
-####1. Deploy for Testing
+#### 1. Deploy for Testing
+
 The application can be tested on physical iOS devices only; push notifications are not available for iOS simulators. 
 
-####2. Log In
+#### 2. Log In
+
 When the application is deployed to an iOS device, you can log into it and begin using the CRUD functionality. Note that access to the application is restricted to users registered with the server-side application and to assist you in getting started a number of default users are preconfigured.
 
 1. Launch the application on the iOS device.
@@ -112,7 +116,8 @@ When the application is deployed to an iOS device, you can log into it and begin
 
     ![contact details](doc/contact-details.png)
 
-####3. Send a Push Message
+#### 3. Send a Push Message
+
 You can send a push notification to your device by creating a new Contact.  
 You can also send a push notification to your device using the `push-contacts-mobile/client/contacts-mobile-webapp` application by completing the following steps (for more information, see the README distributed with the `contacts-mobile-webapp` application):
 
@@ -127,18 +132,17 @@ This automatically triggers a push notification request to the Unified Push Serv
 
 Instead of the regular `didReceiveRemoteNotification` callback invoked when a new notification is received, the application utilizes the 'silent' push feature (offered by iOS 7 and later), so the application can be instructed to fetch the new content even if background (and possible suspended). Thus when the user opens up the app, the content is already available to be viewed. Take a look at the `didReceiveRemoteNotification` notification callback method inside the file `QUICKSTART_HOME/push-contacts-mobile/client/push-contacts-mobile-ios/Contacts/AGAppDelegate.m` for the implementation details.
 
-```objective-c
-- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
-- ...
-}
-```
+        - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
+        - ...
+        }
+
 
 
 FAQ
 ---
 * Which iOS version is supported by JBoss Unified Push CRUD mobile app?
 
-JBoss Unified Push supports iOS 7.0 and later.
+   JBoss Unified Push supports iOS 7.0 and later.
 
 Debug the Application
 =====================

--- a/push-contacts-mobile/server/contacts-mobile-proxy/README.md
+++ b/push-contacts-mobile/server/contacts-mobile-proxy/README.md
@@ -9,6 +9,7 @@ Versions: 1.0
 Source: <https://github.com/jboss-developer/jboss-mobile-quickstarts/>  
 
 ## What is it?
+
 It's a deployable Maven 3 project to help you get started in developing `proxied web applications` with Java EE 6 on JBoss EAP.
 
 _So what is a `proxied web application`?_  
@@ -18,18 +19,21 @@ A proxied web application would be deployed on a server on the other side of tha
 
 ## How do I use it?
 
-###0. System Requirements
+### 0. System Requirements
+
 * [Java 6](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
 * [Maven 3.0](http://maven.apache.org) or later
 * Red Hat JBoss Enterprise Application Platform (EAP) 6.3.0.GA
 
-###1. Prepare Maven Libraries
+### 1. Prepare Maven Libraries
+
 This quickstart is designed to be built with Maven. It requires the JBoss Unified Push and JBoss EAP 6.3.0 Maven repositories.
 
 You must have the JBoss Unified Push Maven repository available and Maven configured to use it. For more information, see the [JBoss Unified Push documentation](https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Unified_Push/) or the README distributed with the JBoss Unified Push Maven repository.
 
 
-###2. Start the JBoss EAP Server
+### 2. Start the JBoss EAP Server
+
 This quickstart requires three instances of JBoss EAP running with the following quickstart deployed:
 `push-contacts-mobile-picketlink-secured`, `contacts-mobile-webapp`, and `contacts-mobile-proxy`
 
@@ -39,105 +43,107 @@ servers.
 
 1. Open a command line and navigate to the root of the JBoss EAP directory.
 2. Start the server instance that will host the `push-contacts-mobile-picketlink-secured` quickstart
-```shell
-For Linux:   EAP_HOME/bin/standalone.sh
-For Windows: EAP_HOME\bin\standalone.bat
-```
+
+        For Linux:   EAP_HOME/bin/standalone.sh
+        For Windows: EAP_HOME\bin\standalone.bat
+
 3. Start the server instance that will host the `contacts-mobile-webapp` quickstart
-```shell
-For Linux:   EAP_HOME/bin/standalone.sh -Djboss.socket.binding.port-offset=100
-For Windows: EAP_HOME\bin\standalone.bat -Djboss.socket.binding.port-offset=100
-```
+
+        For Linux:   EAP_HOME/bin/standalone.sh -Djboss.socket.binding.port-offset=100
+        For Windows: EAP_HOME\bin\standalone.bat -Djboss.socket.binding.port-offset=100
+
 4. Start the server instance that will host the `contacts-mobile-proxy quickstart` quickstart
-```shell
-For Linux:   EAP_HOME/bin/standalone.sh -Djboss.socket.binding.port-offset=200
-For Windows: EAP_HOME\bin\standalone.bat -Djboss.socket.binding.port-offset=200
-```
+
+        For Linux:   EAP_HOME/bin/standalone.sh -Djboss.socket.binding.port-offset=200
+        For Windows: EAP_HOME\bin\standalone.bat -Djboss.socket.binding.port-offset=200
+
 
 **Note:** Adding "-b 0.0.0.0" to the above commands will allow external clients (phones, tablets, desktops, etc...) to connect through your local network.
 
 For example
-```shell
-For Linux:   EAP_HOME/bin/standalone.sh -b 0.0.0.0
-For Windows: EAP_HOME\bin\standalone.bat -b 0.0.0.0
-```
 
-###3. Configure contacts-mobile-webapp
+        For Linux:   EAP_HOME/bin/standalone.sh -b 0.0.0.0
+        For Windows: EAP_HOME\bin\standalone.bat -b 0.0.0.0
+
+
+### 3. Configure contacts-mobile-webapp
+
 By default the `contacts-mobile-webapp` is set up to work directly against `push-contacts-mobile-picketlink-secured` as its backend. For this quickstart we will instead have `contacts-mobile_webapp` work against `contacts-mobile-proxy`. This requires a change to `contacts-mobile-webapp/src/main/webapp/js/app.js`.  
 
 Please open for edit  `contacts-mobile-webapp/src/main/webapp/js/app.js` and update the `CONTACTS.app.serverURL` variable to:
-```java
-CONTACTS.app.serverUrl = "http://localhost:8280/jboss-contacts-mobile-proxy";
-```
 
-###4. Build and Deploy the Quickstart
+        CONTACTS.app.serverUrl = "http://localhost:8280/jboss-contacts-mobile-proxy";
+
+
+### 4. Build and Deploy the Quickstart
+
 1. Make sure you have started the JBoss EAP servers as described above.
 2. Open a command line and navigate to the root directory of this quickstart.
 3. From the `push-contacts-mobile-picketlink-secured` directory run the following command to deploy the quickstart:
-```shell
-mvn clean package jboss-as:deploy
-```
+
+        mvn clean package jboss-as:deploy
+
 4. From the `contacts-mobile-webapp` directory run the following command to deploy the quickstart:
-```shell
-mvn clean package jboss-as:deploy -Djboss-as.port=10099
-```
+
+        mvn clean package jboss-as:deploy -Djboss-as.port=10099
+
 5. From the `contacts-mobile-proxy` directory run the following command to deploy the quickstart:
-```shell
-mvn clean package jboss-as:deploy -Djboss-as.port=10199
-```
+
+        mvn clean package jboss-as:deploy -Djboss-as.port=10199
+
 
 The reason why we need the servers to be started before deploying is that since all server are using the same configuration file, `standalone.xml`, all deployments are persisted to this file. This means that if you restart the server all three quickstart will be deployed which is not desirable. You can either undeploy each quickstart or edit `standalone/configuration/standalone.xml` and remove the `deployments` element.
 
-###5. Test Application
+### 5. Test the Application
+
 Access the running client application in a browser at the following URL: <http://localhost:8180/jboss-contacts-mobile-webapp/#signin-page>.  
 Please refer to the documentation for [contacts-mobile-webapp](../../client/contacts-mobile-webapp) for details about testing these quickstarts.
 
-###6. Undeploy the Quickstart
+### 6. Undeploy the Quickstart
 
 1. Make sure you have started the JBoss EAP server as described above.
 2. Open a command line and navigate to the root directory of this quickstart
 3. From the `contacts-mobile-webapp` directory run the following command to undeploy the quickstart:
-```shell
-mvn jboss-as:undeploy -Djboss-as.port=10099
-```
+
+        mvn jboss-as:undeploy -Djboss-as.port=10099
+
 4. From the `contacts-mobile-proxy` directory run the following command to undeploy the quickstart:
-```shell
-mvn jboss-as:undeploy -Djboss-as.port=10199
-```
+
+        mvn jboss-as:undeploy -Djboss-as.port=10199
+
 5. From the `push-contacts-mobile-picketlink-secured` directory run the following command to undeploy the quickstart:
-```shell
-mvn jboss-as:undeploy
-```
+
+        mvn jboss-as:undeploy
+
 
 ## FAQ
+
 How do I configure the proxy application?
 
 By default there is nothing to configure in this quickstart. But you might be interested in how the proxy is configured. The rules for the proxy can be found in
 [proxy-gateway-config.json](./src/main/webapp/WEB-INF/proxy-gateway-config.json).
 
 This JSON file defines the mapping of URLs that the proxy can handle. You can define as many rules are you like; the basic single rule looks like this:
-```javascript
-{ "rule": "/rest/contacts", "to": "http://localhost:9080/jboss-push-contacts-mobile-picketlink-secured/rest/contacts"}
-```
+
+        { "rule": "/rest/contacts", "to": "http://localhost:9080/jboss-push-contacts-mobile-picketlink-secured/rest/contacts"}
+
 The above can be read as: any request with a request URI of `/rest/contacts` should be sent to the URI of `to`.  
 You can also have path parameters in your rules. For example, we have the following rule in addition to the one above exists in this quickstart:
-```javascript
-{ "rule": "/rest/contacts/{id}", "to": "http://localhost:9080/jboss-push-contacts-mobile-picketlink-secured/rest/contacts{id}"}
-```
+
+        { "rule": "/rest/contacts/{id}", "to": "http://localhost:9080/jboss-push-contacts-mobile-picketlink-secured/rest/contacts{id}"}
+
 
 With this rule, any request URI in the format `/rest/contacts/10001` will be proxied to the URI of `to`.
 
 
 ## Use the Project with an IDE
+
 You can import this project into an IDE (JBoss Developer Studio, NetBeans or IntelliJ IDEA). If you are using JBoss Developer Studio you must import the project as a Maven project. If you are using NetBeans 6.8 or IntelliJ IDEA 9, then you can open the project as an existing project as both of these IDEs recognize Maven projects natively.
 
 You can also start the server and deploy the quickstarts from JBoss Developer Studio. For more information , see the [Get Started with JBoss Developer Studio](http://www.jboss.org/products/devstudio/get-started/ "Get Started with JBoss Developer Studio").
 
 
-If you want to be able to debug into the source code or look at the Javadocs of any library in the project, you can run either of the following two commands to pull them into your local repository. The IDE should then detect them.
+If you want to debug the source code of any library in the project, run the following command to pull the source into your local repository. The IDE should then detect it.
 
-```shell
-$ mvn dependency:sources
-$ mvn dependency:resolve -Dclassifier=javadoc
-```
+    mvn dependency:sources
 

--- a/push-contacts-mobile/server/push-contacts-mobile-picketlink-secured/README.md
+++ b/push-contacts-mobile/server/push-contacts-mobile-picketlink-secured/README.md
@@ -9,6 +9,7 @@ Versions: 1.0
 Source: <https://github.com/jboss-developer/jboss-mobile-quickstarts/>  
 
 ## What is it?
+
 This quickstart demonstrates how to develop secured server-side applications with push functionality, centered around a CRUD contacts application. It creates a PicketLink secured Java EE 6 application using JAX-RS, CDI 1.0, EJB 3.1, JPA 2.0 and Bean Validation 1.0.
 
 When the `push-contacts-mobile-picketlink-secured` application is deployed, the push functionality enables the application to register with the running JBoss Unified Push Server instance and send it push notification requests. The server-side application rest endpoints are secured with PicketLink and can only be accessed by client applications with authenticated users.
@@ -24,17 +25,20 @@ A public API will become available in a future EAP release and the private class
 
 ## How do I use it?
 
-###0. System Requirements
+### 0. System Requirements
+
 * [Java 6](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
 * [Maven 3.0](http://maven.apache.org) or later
 * Red Hat JBoss Enterprise Application Platform (EAP) 6.3.0.GA
 
-###1. Prepare Maven Libraries
+### 1. Prepare Maven Libraries
+
 This quickstart is designed to be built with Maven. It requires the JBoss Unified Push and JBoss EAP 6.3.0 Maven repositories.
 
 You must have the JBoss Unified Push Maven repository available and Maven configured to use it. For more information, see the [JBoss Unified Push documentation](https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Unified_Push/) or the README distributed with the JBoss Unified Push Maven repository.
 
-###2. Register Application with Push Services
+### 2. Register Application with Push Services
+
 You must register the application with the Unified Push Server. This requires a running Unified Push Server instance. For information on installing the Unified Push Server, see the README distributed with the Unified Push Server or the [JBoss Unified Push documentation](https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Unified_Push/).
 
 1. Log into the Unified Push Server console.
@@ -42,59 +46,62 @@ You must register the application with the Unified Push Server. This requires a 
 3. In the `Name` and `Description` fields, type values for the application and click `Create`.
 4. When created, click the application name and make note of the `Server URL`, `Application ID`, and `Master Secret`.
 
-###3. Customize JBoss Unified Push Java Sender and Build Application
+### 3. Customize JBoss Unified Push Java Sender and Build Application
+
 The project source code must be customized with the unique metadata assigned to the application by the JBoss Unified Push Server. 
 
 1. Open [quickstarts-config.json](./src/main/resources/META-INF/quickstarts-config.json) configuration file for editing.
 2. Enter the ` serverUrl `,  ` pushApplicationId ` and ` masterSecret ` parameters.
 3. Save the file.
 4. Build the application
-```shell
-$ cd QUICKSTART_HOME/push-contacts-mobile/server/push-contacts-mobile-picketlink-secured
-$ mvn clean package
-```
 
-###4. Test Application
+        cd QUICKSTART_HOME/push-contacts-mobile/server/push-contacts-mobile-picketlink-secured
+        mvn clean package
 
-####0. Prerequisites
+### 4. Test the Application
+
+#### 0. Prerequisites
+
 The Unified Push Server must be running before the application is deployed to ensure that it successfully registers with the Unified Push Server on deployment.
 
-####1. Deploy for Testing
+#### 1. Deploy for Testing
 
 1. Start JBoss EAP
-```shell
-For Linux:   EAP_HOME/bin/standalone.sh
-For Windows: EAP_HOME\bin\standalone.bat
-```
+
+        For Linux:   EAP_HOME/bin/standalone.sh
+        For Windows: EAP_HOME\bin\standalone.bat
+
 2. Build and deploy the packaged application
-```shell
-$ cd QUICKSTART_HOME/push-contacts-mobile/server/push-contacts-mobile-picketlink-secured
-$ mvn clean package jboss-as:deploy
-```
+
+        cd QUICKSTART_HOME/push-contacts-mobile/server/push-contacts-mobile-picketlink-secured
+        mvn clean package jboss-as:deploy
+
 This deploys `QUICKSTART_HOME/push-contacts-mobile/server/push-contacts-mobile-picketlink-secured/target/jboss-push-contacts-mobile-picketlink-secured.war` to the running instance of the server.
 
 **Note:** Adding "-b 0.0.0.0" to the above commands will allow external clients (phones, tablets, desktops, etc...) to connect through your local network.
 For example
-```shell
-For Linux:   EAP_HOME/bin/standalone.sh -b 0.0.0.0
-For Windows: EAP_HOME\bin\standalone.bat -b 0.0.0.0
-```
 
-####2. Send a Push Message
+        For Linux:   EAP_HOME/bin/standalone.sh -b 0.0.0.0
+        For Windows: EAP_HOME\bin\standalone.bat -b 0.0.0.0
+
+
+#### 2. Send a Push Message
+
 You can create a new contact using any of the client applications.  
 Please follow the `Build and Deploy the Quickstart` instructions in [contacts-mobile-webapp](../../client/contacts-mobile-webapp) which describe how to build, deploy, and access the web application.  
 For information on building and deploying any of the client application variants, see the READMEs distributed with these applications.  
 
-####3. Undeploy the Quickstart
+#### 3. Undeploy the Quickstart
 
 1. Make sure you have started the JBoss EAP server as described above.
 2. When you are finished testing, type this command to undeploy the archive:
-```shell
-$ cd QUICKSTART_HOME/push-contacts-mobile/server/push-contacts-mobile-picketlink-secured
-$ mvn jboss-as:undeploy
-```
+
+        cd QUICKSTART_HOME/push-contacts-mobile/server/push-contacts-mobile-picketlink-secured
+        mvn jboss-as:undeploy
+
 
 ## FAQ
+
 Why cannot I enter a date in the birthdate field?
 
 * Chrome has a [bug](https://code.google.com/p/chromium/issues/detail?id=232296) in it.
@@ -103,13 +110,12 @@ Why cannot I enter a date in the birthdate field?
 * Firefox, IE, and Safari require strict formatting of YYYY-DD-MM, *Note:* It must be a dash and not a slash.
 
 ## Use the Project with an IDE
+
 You can import this project into an IDE (JBoss Developer Studio, NetBeans or IntelliJ IDEA). If you are using JBoss Developer Studio you must import the project as a Maven project. If you are using NetBeans 6.8 or IntelliJ IDEA 9, then you can open the project as an existing project as both of these IDEs recognize Maven projects natively.
 
 You can also start the server and deploy the quickstarts from JBoss Developer Studio. For more information , see the [Get Started with JBoss Developer Studio](http://www.jboss.org/products/devstudio/get-started/ "Get Started with JBoss Developer Studio").
 
-If you want to be able to debug into the source code or look at the Javadocs of any library in the project, you can run either of the following two commands to pull them into your local repository. The IDE should then detect them.
+If you want to debug the source code of any library in the project, run the following command to pull the source into your local repository. The IDE should then detect it.
 
-```shell
-$ mvn dependency:sources
-$ mvn dependency:resolve -Dclassifier=javadoc
-```
+    mvn dependency:sources
+

--- a/push-helloworld-android/README.md
+++ b/push-helloworld-android/README.md
@@ -9,6 +9,7 @@ Versions: 1.0
 Source: <https://github.com/jboss-developer/jboss-mobile-quickstarts/>  
 
 ## What is it?
+
 This quickstart demonstrates how to include basic push functionality in Android applications using the JBoss Unified Push Android Push plug-in.
 
 This simple project consists of a ready-to-build Android application. Before building the application, you must register the Android variant of the application with a running JBoss Unified Push Server instance and Google Cloud Messaging for Android. The resulting unique IDs and other parameters must then be inserted into the application source code. After this is complete, the application can be built and deployed to Android devices. 
@@ -17,13 +18,15 @@ When the application is deployed to an Android device, the push functionality en
 
 ## How do I run it?
 
-###0. System Requirements
+### 0. System Requirements
+
 * [Java 7](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
 * [Maven 3.1.1](http://maven.apache.org)
 * Latest [Android SDK](https://developer.android.com/sdk/index.html) and [Platform version 19](http://developer.android.com/tools/revisions/platforms.html)
 * Latest [Android Support Library](http://developer.android.com/tools/support-library/index.html) and [Google Play Services](http://developer.android.com/google/play-services/index.html)
 
-###1. Prepare Maven Libraries
+### 1. Prepare Maven Libraries
+
 This quickstart is designed to be built with Maven. It requires the JBoss Unified Push Maven repository and Google libraries.
 
 You must have the JBoss Unified Push Maven repository available and Maven configured to use it. For more information, see the [JBoss Unified Push documentation](https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Unified_Push/) or the README distributed with the JBoss Unified Push Maven repository.
@@ -31,32 +34,33 @@ You must have the JBoss Unified Push Maven repository available and Maven config
 Google does not ship all the required libraries to Maven Central so you must deploy them locally with the helper utility [maven-android-sdk-deployer](https://github.com/mosabua/maven-android-sdk-deployer) as detailed here.
 
 1. Checkout maven-android-sdk-deployer
-```shell
-$ git clone git://github.com/mosabua/maven-android-sdk-deployer.git
-```
+
+        git clone git://github.com/mosabua/maven-android-sdk-deployer.git
+
 2. Set up the environment variable `ANDROID_HOME` to contain the Android SDK path
 3. Install Maven version of Android platform 19
-```shell
-$ cd /path/to/maven-android-sdk-deployer/platforms/android-19
-$ mvn install -N
-```
-4. Install Maven version of google-play-services
-```shell
-$ cd /path/to/maven-android-sdk-deployer/extras/google-play-services
-$ mvn install -N
-```
-5. Install Maven version of compatibility-v4
-```shell
-$ cd /path/to/maven-android-sdk-deployer/extras/compatibility-v4
-$ mvn install -N
-```
-6. Install Maven version of compatibility-v7-appcompat
-```shell
-$ cd /path/to/maven-android-sdk-deployer/extras/compatibility-v7-appcompat
-$ mvn install -N
-```
 
-###2. Register Application with Push Services
+        cd /path/to/maven-android-sdk-deployer/platforms/android-19
+        mvn install -N
+
+4. Install Maven version of google-play-services
+
+        cd /path/to/maven-android-sdk-deployer/extras/google-play-services
+        mvn install -N
+
+5. Install Maven version of compatibility-v4
+
+        cd /path/to/maven-android-sdk-deployer/extras/compatibility-v4
+        mvn install -N
+
+6. Install Maven version of compatibility-v7-appcompat
+
+        cd /path/to/maven-android-sdk-deployer/extras/compatibility-v7-appcompat
+        mvn install -N
+
+
+### 2. Register the Application with Push Services
+
 First, you must register the application with Google Cloud Messaging for Android and enable access to the Google Cloud Messaging for Android APIs and Google APIs. This ensures access to the APIs by the Unified Push Server when it routes push notification requests from the application to the GCM. Registering an application with GCM requires that you have a Google account.
 
 1. Log into the [Google Cloud Console](https://console.developers.google.com)
@@ -79,39 +83,43 @@ Second, you must register the application and an Android variant of the applicat
 8. Click `Add`.
 9. When created, expand the variant name and make note of the `Server URL`, `Variant ID`, and `Secret`.
 
-###3. Customize and Build Application
+### 3. Customize and Build Application
+
 The project source code must be customized with the unique metadata assigned to the application variant by the Unified Push Server and GCM. 
 
 1. Open `QUICKSTART_HOME/push-helloworld-android/src/org/jboss/aerogear/unifiedpush/helloworld/Constants.java` for editing.
 2. Enter the application variant values allocated by the Unified Push Server and GCM for the following constants:
-```java
-String UNIFIED_PUSH_URL = "";
-String VARIANT_ID = "";
-String SECRET = "";
-String GCM_SENDER_ID = "";
-```
+
+        String UNIFIED_PUSH_URL = "";
+        String VARIANT_ID = "";
+        String SECRET = "";
+        String GCM_SENDER_ID = "";
+
 3. Save the file.
 4. Build the application
-```shell
-$ cd QUICKSTART_HOME/push-helloworld-android
-$ mvn compile
-```
 
-###4. Test Application
+        cd QUICKSTART_HOME/push-helloworld-android
+        mvn compile
 
-####0. Prerequisites
+
+### 4. Test the Application
+
+#### 0. Prerequisites
+
 The Unified Push Server must be running before the application is deployed to ensure that the device successfully registers with the Unified Push Server on application deployment.
 
-####1. Deploy for testing
+#### 1. Deploy the Application for testing
+
 The application can be tested on physical Android devices only; push notifications are not available for Android emulators. To deploy, run and debug the application on an Android device attached to your system, on the command line enter the following:
-```shell
-$ cd QUICKSTART_HOME/push-helloworld-android
-$ mvn clean package android:deploy android:run
-```
+
+        cd QUICKSTART_HOME/push-helloworld-android
+        mvn clean package android:deploy android:run
+
 
 Application output is displayed in the command line window.
 
-####2. Send a Push Message
+#### 2. Send a Push Message
+
 You can send a push notification to your device using the Unified Push Server console by completing the following steps:
 
 1. Log into the Unified Push Server console.
@@ -126,28 +134,28 @@ You can send a push notification to your device using the Unified Push Server co
 
 `RegisterActivity` is invoked right after a successful application login. The Activity life cycle `onCreate` is called first invoking the `register` method — attempting to register the application to receive push notifications.
 
-```java
-PushConfig config = new PushConfig(new URI(UNIFIED_PUSH_URL), GCM_SENDER_ID);
-config.setVariantID(VARIANT_ID);
-config.setSecret(SECRET);
 
-Registrations registrations = new Registrations();
-PushRegistrar registrar = registrations.push("register", config);
-registrar.register(getApplicationContext(), new Callback<Void>() {
-    @Override
-    public void onSuccess(Void data) {
-        Toast.makeText(getApplicationContext(),
-                getApplicationContext().getString(R.string.registration_successful),
-                Toast.LENGTH_LONG).show();
-    }
+        PushConfig config = new PushConfig(new URI(UNIFIED_PUSH_URL), GCM_SENDER_ID);
+        config.setVariantID(VARIANT_ID);
+        config.setSecret(SECRET);
+        
+        Registrations registrations = new Registrations();
+        PushRegistrar registrar = registrations.push("register", config);
+        registrar.register(getApplicationContext(), new Callback<Void>() {
+            @Override
+            public void onSuccess(Void data) {
+                Toast.makeText(getApplicationContext(),
+                        getApplicationContext().getString(R.string.registration_successful),
+                        Toast.LENGTH_LONG).show();
+            }
+        
+            @Override
+            public void onFailure(Exception e) {
+                Toast.makeText(getApplicationContext(), e.getMessage(), Toast.LENGTH_LONG).show();
+                finish();
+            }
+        });
 
-    @Override
-    public void onFailure(Exception e) {
-        Toast.makeText(getApplicationContext(), e.getMessage(), Toast.LENGTH_LONG).show();
-        finish();
-    }
-});
-```
 
 ### Receiving Notifications
 
@@ -155,31 +163,31 @@ Before the usage of GCM notifications on Android, we need to include some permis
 
 To enable the permissions we add these as child of the manifest element.
 
-```xml
-<uses-permission android:name="android.permission.INTERNET" />
-<uses-permission android:name="android.permission.GET_ACCOUNTS" />
-<uses-permission android:name="android.permission.WAKE_LOCK" />
-<uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
 
-<permission
-    android:name="com.mypackage.C2D_MESSAGE"
-    android:protectionLevel="signature" />
+        <uses-permission android:name="android.permission.INTERNET" />
+        <uses-permission android:name="android.permission.GET_ACCOUNTS" />
+        <uses-permission android:name="android.permission.WAKE_LOCK" />
+        <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
+        
+        <permission
+            android:name="com.mypackage.C2D_MESSAGE"
+            android:protectionLevel="signature" />
+        
+        <uses-permission android:name="org.jboss.aerogear.unifiedpush.helloworld" />
 
-<uses-permission android:name="org.jboss.aerogear.unifiedpush.helloworld" />
-```
 
 And add this element as a child of the application element, to register the default JBoss Unified Push for Android broadcast receiver. It will receive all messages and dispatch the message to registered handlers.
 
-```xml
-<receiver
-    android:name="org.jboss.aerogear.android.unifiedpush.AeroGearGCMMessageReceiver"
-    android:permission="com.google.android.c2dm.permission.SEND" >
-    <intent-filter>
-        <action android:name="com.google.android.c2dm.intent.RECEIVE" />
-        <category android:name="org.jboss.aerogear.unifiedpush.helloworld" />
-    </intent-filter>
-</receiver>
-```
+
+        <receiver
+            android:name="org.jboss.aerogear.android.unifiedpush.AeroGearGCMMessageReceiver"
+            android:permission="com.google.android.c2dm.permission.SEND" >
+            <intent-filter>
+                <action android:name="com.google.android.c2dm.intent.RECEIVE" />
+                <category android:name="org.jboss.aerogear.unifiedpush.helloworld" />
+            </intent-filter>
+        </receiver>
+
 
 All push messages are received by an instance of `AeroGearGCMMessageReceiver`. They are processed and passed to Registrations via the `notifyHandlers` method.
 
@@ -187,19 +195,19 @@ The `NotificationBarMessageHandler` is able to receive that message and show it 
 
 In the `MessagesActivity` we need to remove the handler when the Activity goes into the background and re-enable it when it comes into the foreground.
 
-```java
-@Override
-protected void onResume() {
-    super.onResume();
-    Registrations.registerMainThreadHandler(this);
-    Registrations.unregisterBackgroundThreadHandler(NotificationBarMessageHandler.instance);
-}
 
-@Override
-protected void onPause() {
-    super.onPause();
-    Registrations.unregisterMainThreadHandler(this);
-    Registrations.registerBackgroundThreadHandler(NotificationBarMessageHandler.instance);
-}
-```
+        @Override
+        protected void onResume() {
+            super.onResume();
+            Registrations.registerMainThreadHandler(this);
+            Registrations.unregisterBackgroundThreadHandler(NotificationBarMessageHandler.instance);
+        }
+        
+        @Override
+        protected void onPause() {
+            super.onPause();
+            Registrations.unregisterMainThreadHandler(this);
+            Registrations.registerBackgroundThreadHandler(NotificationBarMessageHandler.instance);
+        }
+
 

--- a/push-helloworld-cordova/README.md
+++ b/push-helloworld-cordova/README.md
@@ -9,6 +9,7 @@ Versions: 1.0
 Source: <https://github.com/jboss-developer/jboss-mobile-quickstarts/>  
 
 ## What is it?
+
 This quickstart demonstrates how to include basic push functionality in Cordova applications using the JBoss Unified Push Cordova Push plug-in.
 
 This simple project consists of a ready-to-build Cordova application. Before building the application, you must register the Android or iOS variant of the application with a running JBoss Unified Push Server instance and Google Cloud Messaging for Android or Apple Push Notification Service for iOS. The resulting unique IDs and other parameters must then be inserted into the application source code. After this is complete, the application can be built and deployed to Android or iOS devices.
@@ -17,74 +18,77 @@ When the application is deployed to an Android or iOS device, the push functiona
 
 ## How do I run it?
 
-###0. System requirements
+### 0. System requirements
 
 The Cordova command line tooling is based on node.js so first you'll need to [install node](http://nodejs.org/download/), then you can install Cordova by executing:
-```shell
-npm install -g cordova
-```
+
+        npm install -g cordova
+
 
 To deploy on iOS you need to install the ios-deploy package as well
-```shell
-npm install -g ios-deploy
-```
+
+        npm install -g ios-deploy
+
 
 #### iOS
+
 For iOS you'll need a valid provisioning profile as you will need to test on an actual device (push notification is not available when using a simulator).
 Replace the bundleId with your bundleId (the one associated with your certificate), by editing the config.xml at the root of this project, change the id attribute of the `widget` node. After that run a `cordova platform rm ios` followed by `cordova platform add ios` to change the Xcode project template.
 
 If you want to change your bundleId later on, you will still have to run a `cordova platform rm ios` followed by `cordova platform add ios` to change the Xcode project template.
 
 #### Android
+
 To deploy and run Cordova applications on Android the Apache Ant tool needs to be [installed](http://ant.apache.org/manual/install.html).
 
 
-###1. Register Application with Push Services
+### 1. Register Application with Push Services
 
 For the configuration and registration of Android or iOS Applications with PushServices, please refer to the specific guides inside *push-helloworld-android* and *push-helloworld-ios* quickstarts.
 
-###2. Customize and Build Application
+### 2. Customize and Build Application
+
 In `www/js/index.js` find the `pushConfig` and change `pushServerURL` with the url of your Unified Push Server instance. You also need to change `senderID`, `variantID` and `variantSecret` with the values assigned by Unified Push Server and GCM or APNS:
 
-```javascript
-var pushConfig = {
-   pushServerURL: "<pushServerURL e.g http(s)//host:port/context >",
-   android: {
-      senderID: "<senderID e.g Google Project ID only for android>",
-      variantID: "<variantID e.g. 1234456-234320>",
-      variantSecret: "<variantSecret e.g. 1234456-234320>"
-   },
-   ios: {
-      variantID: "<variantID e.g. 1234456-234320>",
-      variantSecret: "<variantSecret e.g. 1234456-234320>"
-   }
-};
+        var pushConfig = {
+           pushServerURL: "<pushServerURL e.g http(s)//host:port/context >",
+           android: {
+              senderID: "<senderID e.g Google Project ID only for android>",
+              variantID: "<variantID e.g. 1234456-234320>",
+              variantSecret: "<variantSecret e.g. 1234456-234320>"
+           },
+           ios: {
+              variantID: "<variantID e.g. 1234456-234320>",
+              variantSecret: "<variantSecret e.g. 1234456-234320>"
+           }
+        };
 
-```
 
 **Note:** You can also copy/paste these settings from your Unified Push Server console
 
-###3. Install platforms
+### 3. Install platforms
 
 After changing the push configuration you can install the platforms you want on the Cordova app. JBoss Unified Push for Cordova currently supports Android and iOS.
-```shell
-cordova platform add <android or ios>
-```
 
-###4. Add JBoss Unified Push Cordova Push plug-in
+        cordova platform add <android or ios>
+
+
+### 4. Add JBoss Unified Push Cordova Push plug-in
+
 You now need to add the plugin to the Cordova app.
-```shell
-cordova plugin add `QUICKSTART_HOME/cordova_pushplugin/org.jboss.aerogear.cordova.push`
-```
 
-###5. Test Application
+        cordova plugin add `QUICKSTART_HOME/cordova_pushplugin/org.jboss.aerogear.cordova.push`
+
+
+### 5. Test the Application
 
 The application can be tested on physical Android or iOS devices only; push notifications are not available for Android emulators nor iOS simulators. To deploy, run and debug the application on an Android or iOS device attached to your system, on the command line enter the following:
-```shell
-cordova run <android or ios>
-```
+
+        cordova run <android or ios>
+
 
 #### Send a Push Message
+
 You can send a push notification to your device using the Unified Push Server console by completing the following steps:
 
 1. Log into the Unified Push Server console.
@@ -96,6 +100,7 @@ You can send a push notification to your device using the Unified Push Server co
 ## How does it work?
 
 ### Registration
+
 When you start the application Cordova will fire a `deviceready` event when Cordova initialization is done and the device is ready (see `www/js/index.js`). On this event the `register` function will be executed registering the device with the Unified Push Server. The first argument is a function that gets executed when the device receives a push event, followed by a success and errorCallback that are invoked when the register was successful or not and the last parameter is the push configuration that indicates where the push server is located and which variant/secret to use. When registration is successful it will display this on the UI. You can also verify that the registration was successful by going to the console there a new instance will have appeared with your deviceId, platform and status.
 
 
@@ -124,12 +129,16 @@ Run the project on a device:
 Debug the Application
 =====================
 
-Start a browser Chrome for Android or Safari for iOS
+1. Start a browser Chrome for Android or Safari for iOS
 
-iOS
-* Develop -> &lt;device name> -> index.html
+2. Follow the instructions for the mobile device
 
-Android
-* Menu -> Tools -> Inspect Devices -> inspect
+   * For iOS
+
+        Develop -> &lt;device name> -> index.html
+
+   * For Android
+
+        Menu -> Tools -> Inspect Devices -> inspect
 
 

--- a/push-helloworld-cordova/hooks/README.md
+++ b/push-helloworld-cordova/hooks/README.md
@@ -29,6 +29,7 @@ integrating your own build systems or integrating with version control systems.
 __Remember__: Make your scripts executable.
 
 ## Hook Directories
+
 The following subdirectories will be used for hooks:
 
     after_build/

--- a/push-helloworld-ios/README.md
+++ b/push-helloworld-ios/README.md
@@ -17,11 +17,12 @@ When the application is deployed to an iOS device, the push functionality enable
 
 ## How do I run it?
 
-###0. System requirements
+### 0. System requirements
+
 * iOS 7.X
 * Xcode version 5.1.X
 
-###1. Configuration
+### 1. Configuration
 
 #### Creation of Certificate Signing Request and SSL certificate for APNs
 
@@ -42,7 +43,7 @@ In order to test Push Notifications you neeed to create a _Provisioning Profile_
   *  `Development Provisioning Profile`: In the _Provisioning Portal_ you need to create an _iOS App Development_ provisioning profile, so that you can test the Push Notifications on your own iOS devices. Select the `App ID` that you created earlier and your _Developer Certificate_. Select a _Test_ Device, give it a Profile Name and generate it. Now download the Profile and open the file. Go to `Xcode -> preferences...` menu, select the `Account` tab, on the right bottom corner click `View details...` and you should see your provisioning profile.
   *  `Distribution Provisioning Profile`: In order to test Push Notifications on a `production environment`, you need to create an _iOS App Distribution_ provisioning profile in the _Provisioning Portal_. Select the `App ID`, that you created earlier and your _Production Certificate_. You still need a _test device_ to try your _production_ app with your _distribution provisioning profile_. Select a _Test_ Device, give it a Profile Name and generate it. Now download the Profile and open the file. Go to `Xcode -> preferences...` menu, select the `Account` tab, on the right bottom corner click `View details...` and you should see your provisioning profile.
   
-###2. Register Application with Push Services
+### 2. Register Application with Push Services
 
 You must register the application and an iOS variant of the application with the Unified Push Server. This requires a running Unified Push Server instance and uses the unique metadata assigned to the application by APNS. For information on installing the Unified Push Server, see the [JBoss Unified Push documentation](https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Unified_Push/).
 
@@ -57,7 +58,7 @@ You must register the application and an iOS variant of the application with the
 9. When created, expand the variant name and make note of the `Server URL`, `Variant ID`, and `Secret`.
 
 
-###3. Customize and Build Application
+### 3. Customize and Build Application
 
 Replace the bundleId with your bundleId (the one associated with your certificate).
 Go to `HelloWorld target -> Info` and modify the `Bundle Identifier`:
@@ -117,9 +118,10 @@ In `HelloWorld/AGAppDelegate.m` find the pushConfig and change the server url to
 
 ```
 
-###4. Test Application
+### 4. Test the Application
 
 #### Send a Push Message
+
 You can send a push notification to your device using the Unified Push Server console by completing the following steps:
 
 1. Log into the Unified Push Server console.
@@ -165,7 +167,7 @@ FAQ
 
 * Which iOS version is supported by JBoss Unified Push for iOS libraries?
 
-JBoss Unified Push supports iOS 7.0 and later.
+    JBoss Unified Push supports iOS 7.0 and later.
 
 
 Debug the Application


### PR DESCRIPTION
Added the dist/release-utils.sh script that builds README.html from Markdown.
The script chokes on a few things, so made the following modifications.
- The triple tick marks causes an exception,, so I removed them and indented 8 spaces instead.
- Added a blank like after each heading so the next line is not appended.
- Replaced some quickstart names with links to the quickstart README files.
- Removed sections that are not applicable to these quickstarts.
- Fixed some broken links.
- Also did minor text changes.
