### PR TITLE
Change style of URL parameters

### DIFF
--- a/push-contacts-mobile/server/contacts-mobile-proxy/SERVICES.md
+++ b/push-contacts-mobile/server/contacts-mobile-proxy/SERVICES.md
@@ -45,7 +45,7 @@ MemberService End Points
 ```
 
 ### Find a member by it's ID.
-#### /rest/members/\<id>
+#### /rest/members/{id}
 * Request type: GET
 * Return type: JSON
 * Response example:

--- a/push-contacts-mobile/server/push-contacts-mobile-picketlink-secured/SERVICES.md
+++ b/push-contacts-mobile/server/push-contacts-mobile-picketlink-secured/SERVICES.md
@@ -45,7 +45,7 @@ ContactService End Points
 ```
 
 ### Find a contact by it's ID.
-#### /rest/contacts/\<id>
+#### /rest/contacts/{id}
 * Request type: GET
 * Return type: JSON
 * Response example:


### PR DESCRIPTION
I propose that we indicate URL parameter with {}, because in a lot of Markdown editors, id parameter would render as HTML tag and won't be visible.
